### PR TITLE
Finish off (now apparently working) source_from_anki.yaml

### DIFF
--- a/builder_files/source_from_anki.yaml
+++ b/builder_files/source_from_anki.yaml
@@ -1,10 +1,10 @@
 - generate deck parts:
   - from crowd anki:
-      folder: build/Ultimate Geography/
+      folder: brain_brew_build/Ultimate Geography/
       notes:
         name: standard notes
         sort_order: [Country]
-        #save_to_file: src/deck_parts/notes/english.yaml
+        save_to_file: src/deck_parts/notes/english.yaml
       note_models:
         - name: Ultimate Geography
           save_to_file: src/deck_parts/note_models/Ultimate Geography.yaml
@@ -15,30 +15,47 @@
         from_notes: true
         from_note_models: true
 
-#- generate csvs:
-#    notes: standard notes
-#
-#    note_model_mappings:
-#      - note_models:
-#          - Ultimate Geography
-#
-#        columns_to_fields:
-#          guid: guid
-#          tags: tags
-#
-#          country: Country
-#          country info: Country Info
-#
-#          capital: Capital
-#          capital info: Capital Info
-#          capital hint: Capital hint
-#
-#          flag: flag
-#          flag similarity: Flag similarity
-#
-#          map: map
-#
-#        personal_fields: []
-#
-#    file_mappings:
-#      - file: src/
+- generate csvs:
+   notes: standard notes
+
+   note_model_mappings:
+     - note_models:
+         - Ultimate Geography
+
+       columns_to_fields:
+         guid: guid
+         tags: tags
+
+         country: Country
+         country info: Country Info
+
+         capital: Capital
+         capital info: Capital Info
+         capital hint: Capital hint
+
+         flag: flag
+         flag similarity: Flag similarity
+
+         map: map
+
+       personal_fields: []
+
+   file_mappings:
+      - file: src/data/split/main.csv
+        note_model: Ultimate Geography
+
+        derivatives:
+          - file: src/data/split/country.csv
+            sort_by_columns: [ country ]
+          - file: src/data/split/country_info.csv
+            sort_by_columns: [ country ]
+
+          - file: src/data/split/capital.csv
+            sort_by_columns: [ country ]
+          - file: src/data/split/capital_info.csv
+            sort_by_columns: [ country ]
+          - file: src/data/split/capital_hint.csv
+            sort_by_columns: [ country ]
+
+          - file: src/data/split/flag_similarity.csv
+            sort_by_columns: [ country ]


### PR DESCRIPTION
I wrote this to check whether I (mostly) get the syntax.

Round-tripping (running `source_to_anki.yaml` and then `source_from_anki.yaml` works with only the following "cosmetic" changes:

1. Addition of "Windows newlines" (carriage returns) in all the CSV files.

2. Changing of multi-line quoting style (block vs. flow (?)) and ordering of keys.

<hr/>

It only converts from the English crowdanki deck. I'm not quite sure what's the intended way of dealing with multiple languages, though it seems that having a builder file per-language makes most sense:

1. Converting multiple CrowdAnki JSONs at the same time could potentially result in conflicts in the note model YAMLs.

2. In general, a user will only have a single CrowdAnki JSON that they want converted, so requiring the presence of all languages would be annoying.

OTOH when also combined with the extended deck, this might result in a proliferation of builder files.