### PR TITLE
[2/10] Brain Brew: add English Extended and Experimental variants

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRAINBREW_VERSION: 1.0.0-alpha.4
-      EXPECTED_TARGETS: '1'
+      EXPECTED_TARGETS: '3'
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix

--- a/brainbrew.yaml
+++ b/brainbrew.yaml
@@ -2,8 +2,32 @@ package:
   id: anki-geo.ultimate-geography
   version: 0.1.0
 base: deck.yaml
-overlays: {}
+overlays:
+  overlay.variant.experimental:
+    file: overlays/variants/experimental.yaml
+    kind: extension
+    depends_on:
+      - overlay.variant.extended
+  overlay.variant.experimental.en:
+    file: overlays/variants/experimental/en.yaml
+    kind: extension
+    depends_on:
+      - overlay.variant.experimental
+  overlay.variant.extended:
+    file: overlays/variants/extended.yaml
+    kind: extension
+  overlay.variant.extended.en:
+    file: overlays/variants/extended/en.yaml
+    kind: extension
+    depends_on:
+      - overlay.variant.extended
 targets:
+  en-experimental:
+    overlays:
+      - overlay.variant.experimental.en
+  en-extended:
+    overlays:
+      - overlay.variant.extended.en
   en-standard:
     overlays: []
 languages:
@@ -12,4 +36,6 @@ languages:
     source: true
     primary_target: standard
     targets:
+      experimental: en-experimental
+      extended: en-extended
       standard: en-standard

--- a/overlays/variants/experimental.yaml
+++ b/overlays/variants/experimental.yaml
@@ -1,0 +1,428 @@
+id: overlay.variant.experimental
+kind: extension
+field_additions:
+  note-type.ultimate-geography:
+    fields:
+      field.region-code: Region code
+    values:
+      note.afghanistan:
+        field.region-code: AF
+      note.albania:
+        field.region-code: AL
+      note.algeria:
+        field.region-code: DZ
+      note.andorra:
+        field.region-code: AD
+      note.angola:
+        field.region-code: AO
+      note.antigua-and-barbuda:
+        field.region-code: AG
+      note.argentina:
+        field.region-code: AR
+      note.armenia:
+        field.region-code: AM
+      note.australia:
+        field.region-code: AU
+      note.austria:
+        field.region-code: AT
+      note.azerbaijan:
+        field.region-code: AZ
+      note.bahrain:
+        field.region-code: BH
+      note.bangladesh:
+        field.region-code: BD
+      note.barbados:
+        field.region-code: BB
+      note.belarus:
+        field.region-code: BY
+      note.belgium:
+        field.region-code: BE
+      note.belize:
+        field.region-code: BZ
+      note.benin:
+        field.region-code: BJ
+      note.bhutan:
+        field.region-code: BT
+      note.bolivia:
+        field.region-code: BO
+      note.bosnia-and-herzegovina:
+        field.region-code: BA
+      note.botswana:
+        field.region-code: BW
+      note.brazil:
+        field.region-code: BR
+      note.brunei:
+        field.region-code: BN
+      note.bulgaria:
+        field.region-code: BG
+      note.burkina-faso:
+        field.region-code: BF
+      note.burundi:
+        field.region-code: BI
+      note.cambodia:
+        field.region-code: KH
+      note.cameroon:
+        field.region-code: CM
+      note.canada:
+        field.region-code: CA
+      note.cape-verde:
+        field.region-code: CV
+      note.central-african-republic:
+        field.region-code: CF
+      note.chad:
+        field.region-code: TD
+      note.chile:
+        field.region-code: CL
+      note.china:
+        field.region-code: CN
+      note.colombia:
+        field.region-code: CO
+      note.comoros:
+        field.region-code: KM
+      note.costa-rica:
+        field.region-code: CR
+      note.croatia:
+        field.region-code: HR
+      note.cuba:
+        field.region-code: CU
+      note.cyprus:
+        field.region-code: CY
+      note.czech-republic:
+        field.region-code: CZ
+      note.democratic-republic-of-the-congo:
+        field.region-code: CD
+      note.denmark:
+        field.region-code: DK
+      note.djibouti:
+        field.region-code: DJ
+      note.dominica:
+        field.region-code: DM
+      note.dominican-republic:
+        field.region-code: DO
+      note.ecuador:
+        field.region-code: EC
+      note.egypt:
+        field.region-code: EG
+      note.el-salvador:
+        field.region-code: SV
+      note.equatorial-guinea:
+        field.region-code: GQ
+      note.eritrea:
+        field.region-code: ER
+      note.estonia:
+        field.region-code: EE
+      note.eswatini:
+        field.region-code: SZ
+      note.ethiopia:
+        field.region-code: ET
+      note.falkland-islands:
+        field.region-code: FK
+      note.faroe-islands:
+        field.region-code: FO
+      note.fiji:
+        field.region-code: FJ
+      note.finland:
+        field.region-code: FI
+      note.france:
+        field.region-code: FR
+      note.french-guiana:
+        field.region-code: GF
+      note.gabon:
+        field.region-code: GA
+      note.georgia:
+        field.region-code: GE
+      note.germany:
+        field.region-code: DE
+      note.ghana:
+        field.region-code: GH
+      note.greece:
+        field.region-code: GR
+      note.greenland:
+        field.region-code: GL
+      note.guadeloupe:
+        field.region-code: GP
+      note.guatemala:
+        field.region-code: GT
+      note.guinea:
+        field.region-code: GN
+      note.guinea-bissau:
+        field.region-code: GW
+      note.guyana:
+        field.region-code: GY
+      note.haiti:
+        field.region-code: HT
+      note.honduras:
+        field.region-code: HN
+      note.hong-kong:
+        field.region-code: HK
+      note.hungary:
+        field.region-code: HU
+      note.iceland:
+        field.region-code: IS
+      note.india:
+        field.region-code: IN
+      note.indonesia:
+        field.region-code: ID
+      note.iran:
+        field.region-code: IR
+      note.iraq:
+        field.region-code: IQ
+      note.ireland:
+        field.region-code: IE
+      note.isle-of-man:
+        field.region-code: IM
+      note.israel:
+        field.region-code: IL
+      note.italy:
+        field.region-code: IT
+      note.ivory-coast:
+        field.region-code: CI
+      note.jamaica:
+        field.region-code: JM
+      note.japan:
+        field.region-code: JP
+      note.jordan:
+        field.region-code: JO
+      note.kazakhstan:
+        field.region-code: KZ
+      note.kenya:
+        field.region-code: KE
+      note.kuwait:
+        field.region-code: KW
+      note.kyrgyzstan:
+        field.region-code: KG
+      note.land-islands:
+        field.region-code: AX
+      note.laos:
+        field.region-code: LA
+      note.latvia:
+        field.region-code: LV
+      note.lebanon:
+        field.region-code: LB
+      note.lesotho:
+        field.region-code: LS
+      note.liberia:
+        field.region-code: LR
+      note.libya:
+        field.region-code: LY
+      note.lithuania:
+        field.region-code: LT
+      note.luxembourg:
+        field.region-code: LU
+      note.madagascar:
+        field.region-code: MG
+      note.malawi:
+        field.region-code: MW
+      note.malaysia:
+        field.region-code: MY
+      note.mali:
+        field.region-code: ML
+      note.martinique:
+        field.region-code: MQ
+      note.mauritania:
+        field.region-code: MR
+      note.mauritius:
+        field.region-code: MU
+      note.mayotte:
+        field.region-code: YT
+      note.mexico:
+        field.region-code: MX
+      note.moldova:
+        field.region-code: MD
+      note.mongolia:
+        field.region-code: MN
+      note.montenegro:
+        field.region-code: ME
+      note.morocco:
+        field.region-code: MA
+      note.mozambique:
+        field.region-code: MZ
+      note.myanmar:
+        field.region-code: MM
+      note.namibia:
+        field.region-code: NA
+      note.nepal:
+        field.region-code: NP
+      note.netherlands:
+        field.region-code: NL
+      note.new-caledonia:
+        field.region-code: NC
+      note.new-zealand:
+        field.region-code: NZ
+      note.nicaragua:
+        field.region-code: NI
+      note.niger:
+        field.region-code: NE
+      note.nigeria:
+        field.region-code: NG
+      note.north-korea:
+        field.region-code: KP
+      note.north-macedonia:
+        field.region-code: MK
+      note.norway:
+        field.region-code: NO
+      note.oman:
+        field.region-code: OM
+      note.pakistan:
+        field.region-code: PK
+      note.palestine:
+        field.region-code: PS
+      note.panama:
+        field.region-code: PA
+      note.papua-new-guinea:
+        field.region-code: PG
+      note.paraguay:
+        field.region-code: PY
+      note.peru:
+        field.region-code: PE
+      note.philippines:
+        field.region-code: PH
+      note.poland:
+        field.region-code: PL
+      note.portugal:
+        field.region-code: PT
+      note.puerto-rico:
+        field.region-code: PR
+      note.qatar:
+        field.region-code: QA
+      note.r-union:
+        field.region-code: RE
+      note.republic-of-the-congo:
+        field.region-code: CG
+      note.romania:
+        field.region-code: RO
+      note.russia:
+        field.region-code: RU
+      note.rwanda:
+        field.region-code: RW
+      note.s-o-tom-and-pr-ncipe:
+        field.region-code: ST
+      note.saudi-arabia:
+        field.region-code: SA
+      note.senegal:
+        field.region-code: SN
+      note.serbia:
+        field.region-code: RS
+      note.sierra-leone:
+        field.region-code: SL
+      note.singapore:
+        field.region-code: SG
+      note.slovakia:
+        field.region-code: SK
+      note.slovenia:
+        field.region-code: SI
+      note.solomon-islands:
+        field.region-code: SB
+      note.somalia:
+        field.region-code: SO
+      note.south-africa:
+        field.region-code: ZA
+      note.south-korea:
+        field.region-code: KR
+      note.south-sudan:
+        field.region-code: SS
+      note.spain:
+        field.region-code: ES
+      note.sri-lanka:
+        field.region-code: LK
+      note.sudan:
+        field.region-code: SD
+      note.suriname:
+        field.region-code: SR
+      note.svalbard:
+        field.region-code: SJ
+      note.sweden:
+        field.region-code: SE
+      note.switzerland:
+        field.region-code: CH
+      note.syria:
+        field.region-code: SY
+      note.taiwan:
+        field.region-code: TW
+      note.tajikistan:
+        field.region-code: TJ
+      note.tanzania:
+        field.region-code: TZ
+      note.thailand:
+        field.region-code: TH
+      note.the-bahamas:
+        field.region-code: BS
+      note.the-gambia:
+        field.region-code: GM
+      note.timor-leste:
+        field.region-code: TL
+      note.togo:
+        field.region-code: TG
+      note.trinidad-and-tobago:
+        field.region-code: TT
+      note.tunisia:
+        field.region-code: TN
+      note.turkey:
+        field.region-code: TR
+      note.turkmenistan:
+        field.region-code: TM
+      note.uganda:
+        field.region-code: UG
+      note.ukraine:
+        field.region-code: UA
+      note.united-arab-emirates:
+        field.region-code: AE
+      note.united-kingdom:
+        field.region-code: GB
+      note.united-states-of-america:
+        field.region-code: US
+      note.uruguay:
+        field.region-code: UY
+      note.uzbekistan:
+        field.region-code: UZ
+      note.vanuatu:
+        field.region-code: VU
+      note.venezuela:
+        field.region-code: VE
+      note.vietnam:
+        field.region-code: VN
+      note.yemen:
+        field.region-code: YE
+      note.zambia:
+        field.region-code: ZM
+      note.zimbabwe:
+        field.region-code: ZW
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    variables:
+      variant.name-suffix:
+        intent: override
+        value: ' [Experimental]'
+        expected_base:
+          value: ' [Extended]'
+    card_templates:
+      template.country-map:
+        intent: merge
+        question_format:
+          intent: merge
+          value: !include templates/ultimate-geography/experimental/country-map-question.html
+        answer_format:
+          intent: merge
+          value: !include templates/ultimate-geography/experimental/country-map-answer.html
+media:
+  media.interactive-map-config-js:
+    intent: add
+    path: _ug-interactive_map_config.js
+    sha256: a6c8862ea95a0257f951ef4fdc9a3c1a7aa069d4bbc04847d064b26bf4885ea0
+  media.interactive-map-init-js:
+    intent: add
+    path: _ug-interactive_map_init.js
+    sha256: fa70e8fa2a501f1360a83652157befa28b1de8a20a9a660f35e520d3c19c6ad2
+  media.jsvectormap-css:
+    intent: add
+    path: _ug-jsvectormap.min.css
+    sha256: fae18b26699328ea81afed84e8a0d8b3f351b07c5290e35714750bd1fcb63bfe
+  media.jsvectormap-js:
+    intent: add
+    path: _ug-jsvectormap.js
+    sha256: e3979d3e3dc42d5de35167faaac2722de730187a909ca4a98b058e8ed6b18f7b
+  media.world-js:
+    intent: add
+    path: _ug-world.js
+    sha256: ae54701d4796a334c7f2168aab07d631c09c0ff6f84d6813744a3cb6c27008c1

--- a/overlays/variants/experimental/en.yaml
+++ b/overlays/variants/experimental/en.yaml
@@ -1,0 +1,11 @@
+id: overlay.variant.experimental.en
+kind: extension
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    adapter_ids:
+      crowdanki:uuid:
+        intent: override
+        value: 2e98b530-7583-5551-1fd7-51e6969d58ed
+        expected_base:
+          value: 43e2586a-9a65-11e8-a777-a0481cc15658

--- a/overlays/variants/extended.yaml
+++ b/overlays/variants/extended.yaml
@@ -1,0 +1,28 @@
+id: overlay.variant.extended
+kind: extension
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    variables:
+      variant.name-suffix:
+        intent: replace
+        value: ' [Extended]'
+        expected_base:
+          value: ''
+    card_templates:
+      template.country-flag:
+        intent: add
+        insert_after: template.capital-country
+        template:
+          name: Country - Flag
+          question_format: !include templates/ultimate-geography/country-flag/question.html
+          answer_format: !include templates/ultimate-geography/country-flag/answer.html
+          adapter_ids: {}
+      template.country-map:
+        intent: add
+        insert_after: template.flag-country
+        template:
+          name: Country - Map
+          question_format: !include templates/ultimate-geography/country-map/question.html
+          answer_format: !include templates/ultimate-geography/country-map/answer.html
+          adapter_ids: {}

--- a/overlays/variants/extended/en.yaml
+++ b/overlays/variants/extended/en.yaml
@@ -1,0 +1,11 @@
+id: overlay.variant.extended.en
+kind: extension
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    adapter_ids:
+      crowdanki:uuid:
+        intent: override
+        value: 0a39f994-daaf-11e8-b984-a0481cc15658
+        expected_base:
+          value: 43e2586a-9a65-11e8-a777-a0481cc15658

--- a/templates/ultimate-geography/experimental/country-map-answer.html
+++ b/templates/ultimate-geography/experimental/country-map-answer.html
@@ -1,0 +1,15 @@
+<link rel="stylesheet" href="_ug-jsvectormap.min.css" data-nn-media-src="_ug-jsvectormap.min.css">
+<div class="value value--top">{{Country}}</div>
+{{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
+
+<hr id=answer>
+
+<div class="type">${label.location}</div>
+<div id="map" class="value value--map" style="display: none"></div>
+<div class="value value--image">{{Map}}</div>
+
+<script src="_ug-jsvectormap.js"></script>
+<script src="_ug-world.js"></script>
+<script src="_ug-interactive_map_config.js"></script>
+<script src="_ug-interactive_map_init.js"
+        data-card-side="answer" data-region-code="{{Region code}}"></script>

--- a/templates/ultimate-geography/experimental/country-map-question.html
+++ b/templates/ultimate-geography/experimental/country-map-question.html
@@ -1,0 +1,46 @@
+<link rel="stylesheet" href="_ug-jsvectormap.min.css" data-nn-media-src="_ug-jsvectormap.min.css">
+<script>
+  sessionStorage.setItem("userConfig",
+    JSON.stringify({
+      commonFeatures: {
+        interactiveEnabled: "true",
+        interactiveMobileEnabled: "true",
+        autoAnswerEnabled: "true",
+        toolTipEnabled: "false",
+      },
+      commonColors: {
+        region: "#fdfbe5",
+        selectedRegion: "#e7f3ea",
+        incorrectRegionHighlight: "#c02637",
+        correctRegionHighlight: "#329446",
+        background: "#b3dff5",
+        border: "#757674",
+        tooltipBackground: "#fdfbe5",
+        tooltipText: "#000000"
+      }
+    }));
+</script>
+<div class="value value--top">{{Country}}</div>
+<hr>
+
+<div class="type">${label.location}</div>
+<div id="map" class="value value--map" style="display: none"></div>
+<div class="value value--image">
+  <svg
+    class="placeholder"
+    xmlns="http://www.w3.org/2000/svg"
+    width="500"
+    height="308"
+    viewBox="0 0 500 308"
+  >
+    <path d="m154 2s-151 44-152 152c-1 108 152 152 152 152h193s151-44 151-152c1-107-151-152-151-152z"></path>
+  </svg>
+</div>
+
+<textarea id="typeans" style="display: none;"></textarea>
+
+<script src="_ug-jsvectormap.js"></script>
+<script src="_ug-world.js"></script>
+<script src="_ug-interactive_map_config.js"></script>
+<script src="_ug-interactive_map_init.js"
+        data-card-side="question" data-region-code="{{Region code}}"></script>


### PR DESCRIPTION
> Stack 2/10 · Previous: #17 · Next: #19

## Summary
- Add declarative overlays for the Extended and Experimental variants.
- Include the Experimental card templates and interactive-map assets.

## Verification
- All three native English targets verify successfully.
