### PR TITLE
[8/10] Translations: classify Taiwan wording as a target adaptation

### DIFF
--- a/overlays/languages/zh.yaml
+++ b/overlays/languages/zh.yaml
@@ -411,7 +411,6 @@ translations:
     Paraguay: '巴拉圭(Paraguay)'
     Paramaribo: '帕拉马里博(Paramaribo)'
     Paris: '巴黎(Paris)'
-    Partially recognised state claimed by China.: '中国宣称对台湾拥有主权，但仅被部分国家承认'
     Partially recognised state claimed by Morocco. Also known as Western Sahara.: '摩洛哥(Morocco)宣称拥有主权但仅被部分国家承认的地区。'
     Partially recognised state claimed by Serbia.: '塞尔维亚(Serbia)宣称拥有主权但仅被部分国家承认的地区。'
     Persian Gulf: '波斯湾(Persian Gulf)'
@@ -1056,6 +1055,12 @@ target_adaptations:
     expected_source: ''
     target: '现名尼德兰(Netherlands)，中文通译为荷兰(Holanda)'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.taiwan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by China.
+    target: '中国宣称对台湾拥有主权，但仅被部分国家承认'
+    reason: target-language geopolitical wording
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation


### PR DESCRIPTION
> Stack 8/10 · Previous: #23 · Next: #25

## Summary
- Move the Simplified Chinese Taiwan description from direct translation into an explicit target adaptation.
- Record its source expectation and geopolitical rationale without changing generated output.

This one is just a first example of the translation system allowing for target_adaptions. I picked this example as it's one of the clearest adaptions for political reasons. Adding the discrepancy into target_adaptions makes no claim on the correctness in either case, it merely notes that there is a difference in the translations meanings and the reason for that.

## Verification
- All 100 targets verify successfully with unchanged goldens.
