### PR TITLE
[9/10] Translations: type localized semantic adaptations

### DIFF
--- a/overlays/languages/cs.yaml
+++ b/overlays/languages/cs.yaml
@@ -17,8 +17,6 @@ translations:
     Algiers: 'Alžír'
     Also known as Burma.: 'Známý též jako Barma.'
     Also known as Cabo Verde.: 'Známé též jako Cabo Verde.'
-    Also known as Czechia.: 'Používané časteji Česká republika.'
-    Also known as East Timor.: 'Známý též jako Timor Leste.'
     Also known as the Gulf of Siam.: 'Známý též jako Záliv Siam.'
     Also known as the Sea of Cortez.: 'Známý též jako Cortézovo moře.'
     'Also spelled as Sana''a.': 'Také psáno jako San''á.'
@@ -261,7 +259,6 @@ translations:
     Panama City: 'Panamá'
     Papua New Guinea: 'Papua Nová Guinea'
     Paris: 'Paříž'
-    Partially recognised state claimed by China.: 'Částečně uznávaný stát nárokovaný Čínou, známý též jako Taiwan.'
     Partially recognised state claimed by Morocco. Also known as Western Sahara.: 'Částečné uznávaný stát nárokovaný Marokem, známý též jako Západní Sahara.'
     Partially recognised state claimed by Serbia.: 'Částečně uznávaný stát nárokováný Srbskem.'
     Persian Gulf: 'Perský záliv'
@@ -1028,6 +1025,12 @@ translations:
       'z:*d{z(~V2': 'c2(xx0>{|K'
       'zSc]-^U=0=': 'l1uc5E8j;X'
 target_adaptations:
+  notes.note.czech-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Czechia.
+    target: 'Používané časteji Česká republika.'
+    reason: 'Czech localization uses Česko as the primary label and presents Česká republika as the more frequent alternate name.'
   notes.note.eswatini.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1049,6 +1052,18 @@ target_adaptations:
     expected_source: ''
     target: 'Známý též jako Pacifik.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.taiwan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by China.
+    target: 'Částečně uznávaný stát nárokovaný Čínou, známý též jako Taiwan.'
+    reason: Czech localization adds the alternate spelling Taiwan for primary label Tchaj-wan.
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: 'Známý též jako Timor Leste.'
+    reason: 'Czech localization uses Východní Timor as the primary label and reverses Timor Leste into the alternate name.'
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/da.yaml
+++ b/overlays/languages/da.yaml
@@ -13,7 +13,6 @@ translations:
     Algeria: Algeriet
     Algiers: Algier
     Also known as Burma.: 'Også kendt som Burma.'
-    Also known as East Timor.: 'Også kendt som Timor-Leste.'
     Also known as Kiev.: 'Også kendt som Kiev.'
     Also known as the Gulf of Siam.: 'Også kendt som Siambugten.'
     American Samoa: Amerikansk Samoa
@@ -65,7 +64,6 @@ translations:
     Celebes Sea: Celebeshavet
     Celtic Sea: Det Keltiske hav
     Central African Republic: Den Centralafrikanske Republik
-    Cetinje is an honorary capital.: Cetinje har status som Montenegros gamle royale hovedstad.
     Chad: Tchad
     China: Kina
     'Chișinău': Chisinau
@@ -193,7 +191,6 @@ translations:
     Palestine: 'Palæstina'
     Papua New Guinea: Papua Ny Guinea
     Partially recognised state claimed by China.: 'Delvist anerkendt stat som Kina gør krav på.'
-    Partially recognised state claimed by Morocco. Also known as Western Sahara.: 'Delvist anerkendt stat som Marokko gør krav på. Også kendt som Saharawi Arabiske Demokratiske Republik.'
     Partially recognised state claimed by Serbia.: 'Delvist anerkendt stat som Serbien gør krav på.'
     Persian Gulf: Persiske Bugt
     Philippine Sea: Filippinske Hav
@@ -273,7 +270,6 @@ translations:
     Turks and Caicos Islands: 'Turks- og Caicosøerne'
     'Tórshavn': Thorshavn
     Ulaanbaatar: Ulan Bator
-    Unincorporated internal area of Norway.: 'Norsk øgruppe.'
     Unincorporated territory of the United States.: 'Et såkaldt Unincorporated Territory under USA.'
     United Arab Emirates: De Forenede Arabiske Emirater
     United Kingdom: Storbritannien
@@ -287,7 +283,6 @@ translations:
     Washington, D.C.: Washington
     While Amsterdam is the official capital, The Hague is the seat of the executive and legislative branches.: 'Selvom Amsterdam er den forfatningsmæssige hovedstad, ligger regeringen i Haag.'
     While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.: 'Selvom Dodoma er den officielle hovedstad er Dar es Salaam de facto sæde for regeringen government.'
-    'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.': 'Selvom El Aaiun er den erklærede hovedstad er Tifariti de facto sæde for regeringen.'
     While Mbabane is the official, executive capital, Lobamba is the traditional, spiritual and legislative capital.: 'Selvom Mbabane er den officielle og udøvende hovedstad er Lobamba den traditionelle, sprituelle og lovgivende hovedstad.'
     While Porto-Novo is the official capital, Cotonou is the de facto seat of government.: 'Selvom Porto-Novo er den officielle hovedstad, er Cotonou de facto sæde for regeringen.'
     While Sucre is the constitutional capital, La Paz is the seat of government.: 'Sucre er officiel hovedstad, mens La Paz er regeringssædet.'
@@ -1068,12 +1063,42 @@ target_adaptations:
     ownership: translation
     expected_source: Officially Luxembourg.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.montenegro.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Cetinje is an honorary capital.
+    target: Cetinje har status som Montenegros gamle royale hovedstad.
+    reason: 'Danish replaces the honorary-capital wording with Cetinje''s historical royal-capital status.'
   notes.note.netherlands.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'Også kendt som Holland.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sahrawi-arab-democratic-republic.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.'
+    target: 'Selvom El Aaiun er den erklærede hovedstad er Tifariti de facto sæde for regeringen.'
+    reason: 'Danish naming policy uses El Aaiun as the primary declared-capital name and omits the source''s inverse alias wording.'
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Morocco. Also known as Western Sahara.
+    target: 'Delvist anerkendt stat som Marokko gør krav på. Også kendt som Saharawi Arabiske Demokratiske Republik.'
+    reason: Danish uses Vestsahara as the primary answer and therefore presents the Sahrawi Arab Democratic Republic as the alternate name.
+  notes.note.svalbard.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Unincorporated internal area of Norway.
+    target: 'Norsk øgruppe.'
+    reason: 'Danish intentionally describes Svalbard as a Norwegian archipelago instead of translating the source''s legal classification.'
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: 'Også kendt som Timor-Leste.'
+    reason: 'Danish uses Østtimor as the primary country label and intentionally presents Timor-Leste as the alternate name.'
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/de.yaml
+++ b/overlays/languages/de.yaml
@@ -33,12 +33,10 @@ translations:
     Austria: 'Österreich'
     Autonomous community of Spain.: Autonome Gemeinschaft Spaniens.
     Autonomous province of South Korea.: 'Autonome Provinz Südkoreas.'
-    Autonomous region of Finland.: 'Auch Ålandinseln. Autonome Region Finnlands.'
     Autonomous region of Italy.: Autonome Region Italiens.
     Autonomous region of Papua New Guinea.: Autonome Region Papua-Neuguineas.
     Autonomous region of Portugal.: Autonome Region Portugals.
     Azerbaijan: Aserbaidschan
-    Azores: 'Azoren (Habichtsinseln)'
     Baghdad: Bagdad
     Balkan Peninsula: Balkanhalbinsel
     Baltic Sea: Ostsee
@@ -74,7 +72,6 @@ translations:
     Central African Republic: Zentralafrikanische Republik
     Cetinje is an honorary capital.: Cetinje ist eine Ehrenhauptstadt.
     Chad: Tschad
-    China: Volksrepublik China
     City of San Marino: Stadt San Marino
     Claimed and controlled: Behauptet und kontrolliert
     Claimed but not controlled: Behauptet, aber nicht kontrolliert
@@ -91,7 +88,6 @@ translations:
     Croatia: Kroatien
     Crown dependency of the United Kingdom.: Kronbesitz der britischen Krone.
     Cuba: Kuba
-    Cyprus: Republik Zypern
     Czech Republic: Tschechien
     Damascus: Damaskus
     Dead Sea: Totes Meer
@@ -231,7 +227,6 @@ translations:
     Pyongyang: 'Pjöngjang'
     Qatar: Katar
     Red Sea: Rotes Meer
-    Region of France.: 'Gebietskörperschaft Frankreichs.'
     Republic of the Congo: Republik Kongo
     Riyadh: Riad
     Romania: 'Rumänien'
@@ -261,7 +256,6 @@ translations:
     Slovenia: Slowenien
     Solomon Islands: Salomonen
     South Africa: 'Südafrika'
-    'South Africa has no legally defined capital: the branches of government are split over three cities: Pretoria (executive), Cape Town (legislative) and Bloemfontein (judicial).': 'Die Regierung sitzt in Pretoria (Exekutive), das Parlament in Kapstadt (Legislative) und das Oberste Berufungsgericht in Bloemfontein (Judikative).'
     South America: 'Südamerika'
     South China Sea: 'Südchinesisches Meer'
     South Korea: 'Südkorea'
@@ -278,8 +272,6 @@ translations:
     Strait of Gibraltar: 'Straße von Gibraltar'
     Strait of Hormuz: 'Straße von Hormus'
     Strait of Malacca: 'Straße von Malakka'
-    Subregion of Oceania comprising thousands of small islands in the central and southern Pacific Ocean.: 'Größte Inselregion Ozeaniens.'
-    Subregion of Oceania comprising thousands of small islands in the western Pacific Ocean.: 'Teilregion von Ozeanien bestehend über 2000 tropischen Inseln und Atollen im westlichen Pazifik.'
     Subregion of Oceania, which includes Vanuatu, the Solomon Islands, Fiji, and Papua New Guinea.: 'Teilregion von Ozeanien, zu der Vanuatu, die Salomonen, Fidschi und Papua-Neuguinea gehören.'
     Sukhumi: Sochumi
     Svalbard: Spitzbergen
@@ -1024,6 +1016,12 @@ target_adaptations:
     expected_source: ''
     target: Auch Atlantik.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.azores.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Azores
+    target: 'Azoren (Habichtsinseln)'
+    reason: German intentionally appends the localized alternate name Habichtsinseln.
   notes.note.balkan-peninsula.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1066,6 +1064,24 @@ target_adaptations:
     expected_source: ''
     target: Auch Sulawesisee.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.china.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: China
+    target: Volksrepublik China
+    reason: 'German intentionally labels the China answer as the People''s Republic of China.'
+  notes.note.corsica.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Region of France.
+    target: 'Gebietskörperschaft Frankreichs.'
+    reason: German intentionally describes Corsica using the more specific French territorial-collectivity category.
+  notes.note.cyprus.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Cyprus
+    target: Republik Zypern
+    reason: German intentionally uses the official polity name Republic of Cyprus for the answer.
   notes.note.czech-republic.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1076,11 +1092,23 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as Gulf of Makran.
     reason: legacy localized decks intentionally leave the untranslated source detail blank
+  notes.note.land-islands.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Autonomous region of Finland.
+    target: 'Auch Ålandinseln. Autonome Region Finnlands.'
+    reason: 'German adds the alternate plural name Ålandinseln to the Finnish autonomous-region description.'
   notes.note.luxembourg.fields.field.capital-info:
     intent: delete
     ownership: translation
     expected_source: Officially Luxembourg.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.micronesia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Subregion of Oceania comprising thousands of small islands in the western Pacific Ocean.
+    target: 'Teilregion von Ozeanien bestehend über 2000 tropischen Inseln und Atollen im westlichen Pazifik.'
+    reason: German intentionally replaces the generic source description with a more specific count and island/atoll characterization.
   notes.note.moldova.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1105,12 +1133,24 @@ target_adaptations:
     expected_source: ''
     target: Auch Arabischer Golf.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.polynesia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Subregion of Oceania comprising thousands of small islands in the central and southern Pacific Ocean.
+    target: 'Größte Inselregion Ozeaniens.'
+    reason: 'German intentionally substitutes a concise size/rank description for the source''s island-count and location description.'
   notes.note.solomon-islands.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: Auch Salomoninseln.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.south-africa.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'South Africa has no legally defined capital: the branches of government are split over three cities: Pretoria (executive), Cape Town (legislative) and Bloemfontein (judicial).'
+    target: 'Die Regierung sitzt in Pretoria (Exekutive), das Parlament in Kapstadt (Legislative) und das Oberste Berufungsgericht in Bloemfontein (Judikative).'
+    reason: German replaces the generic three-branch wording with the concrete institutions seated in each city.
   notes.note.suriname.fields.field.country-info:
     intent: adapt
     ownership: translation

--- a/overlays/languages/es.yaml
+++ b/overlays/languages/es.yaml
@@ -15,7 +15,6 @@ translations:
     Akrotiri and Dhekelia: Acrotiri y Dhekelia
     Algeria: Argelia
     Algiers: Argel
-    Also known as Burma.: 'También conocida como Myanmar.'
     Also known as Czechia.: 'También conocida como Chequia.'
     Also known as the Gulf of Siam.: 'También conocido como golfo de Siam.'
     Also known as the Sea of Cortez.: 'También conocido como mar de Cortés.'
@@ -186,7 +185,6 @@ translations:
     Khartoum: Jartum
     Kinshasa: Kinsasa
     Known as Nur-Sultan between 2019 and 2022: 'Conocida como Nursultán entre 2019 y 2022'
-    Known as Swaziland until 2018.: Oficialmente Esuatini desde 2018.
     Kuwait City: Kuwait
     Kyiv: Kiev
     Kyrgyzstan: 'Kirguistán'
@@ -393,7 +391,6 @@ translations:
     Washington, D.C.: Washington D. C.
     While Amsterdam is the official capital, The Hague is the seat of the executive and legislative branches.: 'Aunque Ámsterdam es la capital oficial, La Haya es la sede del gobierno y del poder legislativo.'
     While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.: Aunque Dodoma es la capital oficial, Dar es-Salam es la capital de facto.
-    'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.': 'Aunque El Aaiún es la capital proclamada, Tifariti es la capital de facto.'
     While Mbabane is the official, executive capital, Lobamba is the traditional, spiritual and legislative capital.: Aunque Mbabane es la capital oficial y ejecutiva, Lobamba es la capital tradicional, espiritual y legislativa.
     While Porto-Novo is the official capital, Cotonou is the de facto seat of government.: 'Aunque Porto Novo es la capital oficial, Cotonú es la capital de facto.'
     While Sucre is the constitutional capital, La Paz is the seat of government.: Aunque Sucre es la capital constitucional, La Paz es sede de gobierno.
@@ -992,6 +989,12 @@ target_adaptations:
     expected_source: ''
     target: 'También conocido como mar de Sulawesi.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.eswatini.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Known as Swaziland until 2018.
+    target: Oficialmente Esuatini desde 2018.
+    reason: Spanish retains Suazilandia as the displayed name and reframes the post-2018 official name as Esuatini.
   notes.note.gulf-of-oman.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1002,6 +1005,18 @@ target_adaptations:
     ownership: translation
     expected_source: Officially Luxembourg.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.myanmar.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Burma.
+    target: 'También conocida como Myanmar.'
+    reason: Spanish uses Birmania as the primary label and intentionally gives Myanmar as the alternate name.
+  notes.note.sahrawi-arab-democratic-republic.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.'
+    target: 'Aunque El Aaiún es la capital proclamada, Tifariti es la capital de facto.'
+    reason: 'Spanish uses the preferred El Aaiún exonym and intentional de facto-capital wording.'
   notes.note.timor-leste.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/fr.yaml
+++ b/overlays/languages/fr.yaml
@@ -13,9 +13,6 @@ translations:
     Albania: Albanie
     Algeria: 'Algérie'
     Algiers: Alger
-    Also known as Burma.: Aussi connue comme le Myanmar.
-    Also known as Czechia.: 'Aussi connue comme la  République tchèque.'
-    Also known as East Timor.: Aussi connu comme le Timor-Leste.
     Also known as the Gulf of Siam.: Aussi connu comme le golfe du Siam.
     Also known as the Sea of Cortez.: 'Aussi connu comme la mer de Cortés.'
     American Samoa: 'Samoa américaines'
@@ -112,7 +109,6 @@ translations:
     Denmark: Danemark
     Denmark Strait: 'Détroit de Danemark'
     Dhaka: Dacca
-    'Disputed; claimed by Israel; Ramallah is the administrative centre.': 'Contestée; revendiquée par Israël; Ramallah est la capitale administrative de fait.'
     'Disputed; claimed by Palestine.': 'Contestée; revendiquée par la Palestine.'
     Dominica: Dominique
     Dominican Republic: 'République dominicaine'
@@ -159,7 +155,6 @@ translations:
     Hanoi: 'Hanoï'
     Havana: La Havane
     Hawaii: 'Hawaï'
-    Historical and cultural region in Northern Europe, which includes the countries of Denmark, Norway and Sweden, and sometimes Finland and Iceland.: 'Région historique et culturelle d''Europe du Nord constituée de trois monarchies constitutionnelles, le Danemark, la Norvège et la Suède, et parfois de façon incorrecte l''Islande et la Finlande.'
     Hudson Bay: 'Baie d''Hudson'
     Hungary: Hongrie
     Iceland: Islande
@@ -299,7 +294,6 @@ translations:
     South America: 'Amérique du Sud'
     South China Sea: 'Mer de Chine méridionale'
     South Korea: 'Corée du Sud'
-    South Ossetia: 'Ossétie du Sud-Alanie'
     South Sudan: Soudan du Sud
     South Tarawa: Tarawa-Sud
     Southern Ocean: 'Océan Austral'
@@ -362,7 +356,6 @@ translations:
     Washington, D.C.: Washington
     While Amsterdam is the official capital, The Hague is the seat of the executive and legislative branches.: 'Bien qu''Amsterdam soit la capitale officielle, La Haye est le siège du gouvernement et du parlement.'
     While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.: 'Bien que Dodoma soit la capitale officielle, Dar es Salaam est le siège du gouvernement.'
-    'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.': 'Bien que Laâyoune soit la capitale déclarée, Tifariti est le siège du gouvernement.'
     While Mbabane is the official, executive capital, Lobamba is the traditional, spiritual and legislative capital.: 'Bien que Mbabane soit la capitale exécutive officielle, Lobamba est la capitale traditionnelle, spirituelle et législative.'
     While Porto-Novo is the official capital, Cotonou is the de facto seat of government.: 'Bien que Porto-Novo soit la capitale officielle, Cotonou est le siège du gouvernement.'
     While Sucre is the constitutional capital, La Paz is the seat of government.: 'Bien que Sucre soit la capitale constitutionnelle, La Paz est le siège du gouvernement.'
@@ -1004,6 +997,12 @@ target_adaptations:
     expected_source: ''
     target: Aussi connu comme la mer de Sulawesi.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.czech-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Czechia.
+    target: 'Aussi connue comme la  République tchèque.'
+    reason: 'French uses Tchéquie as the primary label and intentionally gives République tchèque as the alternate name.'
   notes.note.gulf-of-oman.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1019,6 +1018,42 @@ target_adaptations:
     ownership: translation
     expected_source: Officially Luxembourg.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.myanmar.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Burma.
+    target: Aussi connue comme le Myanmar.
+    reason: French uses Birmanie as the primary label and intentionally gives Myanmar as the alternate name.
+  notes.note.palestine.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Disputed; claimed by Israel; Ramallah is the administrative centre.'
+    target: 'Contestée; revendiquée par Israël; Ramallah est la capitale administrative de fait.'
+    reason: French intentionally describes Ramallah as the de facto administrative capital rather than merely an administrative centre.
+  notes.note.sahrawi-arab-democratic-republic.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.'
+    target: 'Bien que Laâyoune soit la capitale déclarée, Tifariti est le siège du gouvernement.'
+    reason: 'French uses the preferred Laâyoune name, omits the Spanish alias, and simplifies the government-seat wording.'
+  notes.note.scandinavia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Historical and cultural region in Northern Europe, which includes the countries of Denmark, Norway and Sweden, and sometimes Finland and Iceland.
+    target: 'Région historique et culturelle d''Europe du Nord constituée de trois monarchies constitutionnelles, le Danemark, la Norvège et la Suède, et parfois de façon incorrecte l''Islande et la Finlande.'
+    reason: French uses a narrower cultural definition, adds constitutional-monarchy status, and judges the inclusion of Finland and Iceland incorrect.
+  notes.note.south-ossetia.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: South Ossetia
+    target: 'Ossétie du Sud-Alanie'
+    reason: 'French intentionally uses the extended polity name South Ossetia–Alania.'
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: Aussi connu comme le Timor-Leste.
+    reason: French uses Timor oriental as the primary label and intentionally gives Timor-Leste as the alternate name.
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/he.yaml
+++ b/overlays/languages/he.yaml
@@ -20,8 +20,6 @@ translations:
     Alofi: 'אלופי'
     Also known as Burma.: 'ידועה גם בשם בורמה.'
     Also known as Cabo Verde.: 'ידועה גם בשם קאבו ורדה.'
-    Also known as Czechia.: 'ידועה גם בשם הרפובליקה הצ''כית.'
-    Also known as East Timor.: 'ידועה גם בשם טימור-לסטה.'
     Also known as Kiev.: 'ידועה גם בשם קייב.'
     'Also known as Türkiye': 'ידועה גם בשם טורקייה.'
     Also known as the Gulf of Siam.: 'ידוע גם בשם מפרץ סיאם.'
@@ -147,7 +145,6 @@ translations:
     Colombo is often referred to as the capital but Sri Jayawardenepura Kotte, a suburb of Colombo, is the official, legislative capital.: 'קולומבו נקראת לעיתים קרובות הבירה, אך סרי ג''ייוורדנפורה קוטה, פרבר של קולומבו, משמשת כבירה הרשמית והמחוקקת.'
     Comoros: 'קומורו'
     Conakry: 'קונאקרי'
-    Constituent country in the Kingdom of Denmark.: 'חלק אוטונומי מממלכת דנמרק.'
     Constituent country of the Kingdom of the Netherlands.: 'מדינה אוטונומית בממלכת ארצות השפלה.'
     Constituent country of the United Kingdom.: 'אחת מהמדינות המרכיבות את הממלכה המאוחדת.'
     Cook Islands: 'איי קוק'
@@ -246,9 +243,6 @@ translations:
     Hudson Bay: 'מפרץ הדסון'
     Hungary: 'הונגריה'
     Iceland: 'איסלנד'
-    Independent state claimed by Georgia.: 'מדינה עצמאית בפועל שגאורגיה טוענת לריבונות עליה.'
-    Independent state claimed by Moldova.: 'מדינה עצמאית בפועל שמולדובה טוענת לריבונות עליה.'
-    Independent state claimed by Somalia.: 'מדינה עצמאית בפועל שסומליה טוענת לריבונות עליה.'
     India: 'הודו'
     Indian Ocean: 'האוקיינוס ההודי'
     Indonesia: 'אינדונזיה'
@@ -391,8 +385,6 @@ translations:
     Oceania: 'אוקיאניה'
     Official capital was moved from Bujumbura to Gitega in 2019.: 'הבירה הרשמית הועברה מבוג''ומבורה לגיטגה בשנת 2019.'
     Official capital was moved from Malabo to Ciudad de la Paz in 2026.: 'הבירה הרשמית הועברה ממלאבו לסיודד דה לה פאס בשנת 2026.'
-    'Officially Côte d''Ivoire.': 'שמה הרשמי בצרפתית הוא קוט דיוואר.'
-    Officially Luxembourg.: 'שמה הרשמי של הבירה הוא לוקסמבורג.'
     Oman: 'עומאן'
     Oranjestad: 'אורנייסטד'
     Oslo: 'אוסלו'
@@ -587,7 +579,6 @@ translations:
     Wellington: 'ולינגטון'
     While Amsterdam is the official capital, The Hague is the seat of the executive and legislative branches.: 'אמסטרדם היא הבירה הרשמית, אך האג היא מושב הממשלה והפרלמנט.'
     While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.: 'דודומה היא הבירה הרשמית, אך דאר א-סלאם הוא מושב הממשלה בפועל.'
-    'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.': 'אל-עיון היא הבירה המוצהרת, אך תיפאריטי היא מושב הממשלה בפועל.'
     While Mbabane is the official, executive capital, Lobamba is the traditional, spiritual and legislative capital.: 'מבבנה היא הבירה הרשמית והמבצעת, ולובמבה היא הבירה המסורתית, הרוחנית והמחוקקת.'
     While Porto-Novo is the official capital, Cotonou is the de facto seat of government.: 'פורטו-נובו היא הבירה הרשמית, אך קוטונו הוא מושב הממשלה בפועל.'
     While Sucre is the constitutional capital, La Paz is the seat of government.: 'סוקרה היא הבירה החוקתית, אך לה פאס היא מושב הממשלה.'
@@ -658,6 +649,10 @@ translations:
     with star and crescent: 'עם כוכב וסהר'
     with text: 'עם כיתוב'
     'Åland Islands': 'איי אולנד'
+  contextual:
+    notes.note:
+      luxembourg.fields.field.capital-info:
+        Officially Luxembourg.: 'שמה הרשמי של הבירה הוא לוקסמבורג.'
   variables:
     label.capital:
       Capital: 'בירה'
@@ -1000,12 +995,30 @@ translations:
       43c5ba66-9a65-11e8-90c9-a0481cc15658: 35307c16-cdbf-4c06-b3e3-61a654abc1c6
       43e2586a-9a65-11e8-a777-a0481cc15658: f37b2a2a-e97a-4909-8b56-f84c9caa5348
 target_adaptations:
+  notes.note.abkhazia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Georgia.
+    target: 'מדינה עצמאית בפועל שגאורגיה טוענת לריבונות עליה.'
+    reason: Hebrew qualifies Abkhazia and South Ossetia as de facto independent rather than asserting unqualified independent-state status.
   notes.note.arctic-ocean.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'ידוע גם בשם האוקיינוס הארקטי.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.czech-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Czechia.
+    target: 'ידועה גם בשם הרפובליקה הצ''כית.'
+    reason: 'Hebrew uses צ׳כיה as the primary country label and intentionally presents the Czech Republic as the alternate name.'
+  notes.note.faroe-islands.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Constituent country in the Kingdom of Denmark.
+    target: 'חלק אוטונומי מממלכת דנמרק.'
+    reason: Hebrew describes Faroe Islands and Greenland as autonomous parts of the Kingdom of Denmark rather than constituent countries.
   notes.note.finland.fields.field.capital-info:
     intent: adapt
     ownership: translation
@@ -1018,17 +1031,59 @@ target_adaptations:
     expected_source: ''
     target: 'נקראה בעבר גותהוב.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.greenland.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Constituent country in the Kingdom of Denmark.
+    target: 'חלק אוטונומי מממלכת דנמרק.'
+    reason: Hebrew describes Faroe Islands and Greenland as autonomous parts of the Kingdom of Denmark rather than constituent countries.
   notes.note.gulf-of-oman.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: Also known as Gulf of Makran.
     reason: legacy localized decks intentionally leave the untranslated source detail blank
+  notes.note.ivory-coast.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Officially Côte d''Ivoire.'
+    target: 'שמה הרשמי בצרפתית הוא קוט דיוואר.'
+    reason: 'Hebrew identifies Côte d’Ivoire as the official French name while retaining the established Hebrew primary name.'
   notes.note.red-sea.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'ידוע גם בשם הים האדום.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sahrawi-arab-democratic-republic.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.'
+    target: 'אל-עיון היא הבירה המוצהרת, אך תיפאריטי היא מושב הממשלה בפועל.'
+    reason: 'The established Hebrew name collapses the Laayoune and El Aaiún aliases, so Hebrew omits the alternate-name proposition.'
+  notes.note.somaliland.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Somalia.
+    target: 'מדינה עצמאית בפועל שסומליה טוענת לריבונות עליה.'
+    reason: Hebrew qualifies Somaliland as de facto independent rather than asserting unqualified independent-state status.
+  notes.note.south-ossetia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Georgia.
+    target: 'מדינה עצמאית בפועל שגאורגיה טוענת לריבונות עליה.'
+    reason: Hebrew qualifies Abkhazia and South Ossetia as de facto independent rather than asserting unqualified independent-state status.
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: 'ידועה גם בשם טימור-לסטה.'
+    reason: Hebrew uses East Timor as the primary country label and intentionally presents Timor-Leste as the alternate name.
+  notes.note.transnistria.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Moldova.
+    target: 'מדינה עצמאית בפועל שמולדובה טוענת לריבונות עליה.'
+    reason: Hebrew qualifies Transnistria as de facto independent rather than asserting unqualified independent-state status.
 deck:
   name:
     intent: replace

--- a/overlays/languages/it.yaml
+++ b/overlays/languages/it.yaml
@@ -9,9 +9,7 @@ translations:
     Aegean Sea: Mar Egeo
     Akrotiri and Dhekelia: Akrotiri e Dhekelia
     Algiers: Algeri
-    Also known as Burma.: Conosciuta anche come Myanmar.
     Also known as Czechia.: Conosciuta anche come Cechia.
-    Also known as East Timor.: Conosciuto anche come Timor-Leste.
     Also known as the Gulf of Siam.: Conosciuto anche come Golfo della Thailandia.
     Also known as the Sea of Cortez.: Conosciuto anche come Mare di Cortez.
     American Samoa: Samoa Americane
@@ -1010,6 +1008,18 @@ target_adaptations:
     ownership: translation
     expected_source: Officially Luxembourg.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.myanmar.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Burma.
+    target: Conosciuta anche come Myanmar.
+    reason: Italian uses Birmania as the primary label and intentionally gives Myanmar as the alternate name.
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: Conosciuto anche come Timor-Leste.
+    reason: Italian uses Timor Est as the primary label and intentionally gives Timor-Leste as the alternate name.
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/nb.yaml
+++ b/overlays/languages/nb.yaml
@@ -11,8 +11,6 @@ translations:
     Algeria: Algerie
     Algiers: Alger
     Also known as Burma.: 'Også kalt Burma.'
-    Also known as Cabo Verde.: Offisielt Republikken Cabo Verde.
-    Also known as Kiev.: 'Også kjent som Kyiv.'
     Also known as the Gulf of Siam.: 'Også kalt Siambukta.'
     American Samoa: Amerikansk Samoa
     Antarctica: Antarktis
@@ -26,7 +24,6 @@ translations:
     Austria: 'Østerrike'
     Autonomous community of Spain.: 'Selvstyrt område i Spania.'
     Autonomous province of South Korea.: 'Selvstyrt provins i Sør-Korea.'
-    Autonomous region of Finland.: 'Selvstyrt og delimilitarisert øygruppe og landskap i Finland.'
     Autonomous region of Italy.: Delvis selvstyrt region i Italia.
     Autonomous region of Papua New Guinea.: Selvstyrt region i Papua Ny-Guinea.
     Autonomous region of Portugal.: Selvstyrt region i Portugal.
@@ -61,13 +58,11 @@ translations:
     Celebes Sea: 'Celebessjøen'
     Celtic Sea: Det keltiske hav
     Central African Republic: Den sentralafrikanske republikk
-    Cetinje is an honorary capital.: Administrativ hovedstad. Cetinje er historisk hovedstad og presidentens tilholdssted.
     Chad: Tsjad
     China: Kina
     City of San Marino: San Marino by
     Claimed and controlled: Krevd og kontrollert
     Claimed but not controlled: Krevd, men ikke kontrollert
-    Colombo is often referred to as the capital but Sri Jayawardenepura Kotte, a suburb of Colombo, is the official, legislative capital.: 'Regjeringen har sete i Colombo. Sri Jayawardenepura Kotte (kalt Kotte) er en forstad til Colombo der nasjonalforsamlingen har sete. Kotte er altså lovgivende hovedstad.'
     Comoros: Komorene
     Constituent country in the Kingdom of Denmark.: 'Land som utgjør en del av kongeriket Danmark.'
     Constituent country of the United Kingdom.: 'Land som utgjør en del av Storbritannia.'
@@ -98,7 +93,6 @@ translations:
     Falkland Islands: 'Falklandsøyene'
     Faroe Islands: 'Færøyene'
     Federated States of Micronesia: 'Mikronesiaføderasjonen'
-    Formerly Zaire.: 'Offisielt Den demokratiske republikken Kongo. Tidligere Zaïre.'
     Formerly known as Macedonia.: Tidligere Makedonia.
     France: Frankrike
     French Guiana: Fransk Guyana
@@ -116,14 +110,10 @@ translations:
     Gulf of Thailand: Thailandbukta
     Havana: Havanna
     Helsinki: Helsingfors
-    Historical and cultural region in Northern Europe, which includes the countries of Denmark, Norway and Sweden, and sometimes Finland and Iceland.: Skandinavia betegner Sverige, Danmark og Norge. Norden inkluderer nabolandene Finland og Island.
     Hong Kong: Hongkong
     Hudson Bay: Hudsonbukta
     Hungary: Ungarn
     Iceland: Island
-    Independent state claimed by Georgia.: Utbryterstat i Georgia.
-    Independent state claimed by Moldova.: 'Region i Moldova som er en selverklært, men ikke internasjonalt anerkjent, stat.'
-    Independent state claimed by Somalia.: Utbryterrepublikk i Somalia. Fungerer som selvstendig stat, men ikke anerkjent av andre.
     Indian Ocean: Det indiske hav
     Iraq: Irak
     Ireland: Irland
@@ -180,7 +170,6 @@ translations:
     Palestine: Palestina
     Panama City: Panama by
     Papua New Guinea: Papua Ny-Guinea
-    Partially recognised state claimed by China.: 'Offisielt Republikken Kina. Folkerepublikken Kina gjør også krav på områdene.'
     Partially recognised state claimed by Morocco. Also known as Western Sahara.: 'Delvis anerkjent stat som Marokko gjør krav på.'
     Partially recognised state claimed by Serbia.: 'Delvis anerkjent stat som Serbia gjør krav på.'
     Persian Gulf: Persiabukta
@@ -201,12 +190,10 @@ translations:
     Sanaa: Sana
     Santiago: Santiago de Chile
     Saudi Arabia: Saudi-Arabia
-    Scandinavia: Skandinavia og Norden
     Scotland: Skottland
     Sea of Galilee: 'Gennesaretsjøen'
     Sea of Japan: Japanhavet
     Sea of Okhotsk: Okhotskhavet
-    Semi-autonomous region of Tanzania.: Delvis selvstendig stat i Tanzania.
     Seychelles: Seychellene
     Sicily: Sicilia
     Solomon Islands: 'Salomonøyene'
@@ -248,7 +235,6 @@ translations:
     Turkey: Tyrkia
     Turks and Caicos Islands: 'Turks- og Caicosøyene'
     Ukraine: Ukraina
-    Unincorporated internal area of Norway.: 'Norsk øygruppe.'
     Unincorporated territory of the United States.: Uinnlemmet territorium i USA.
     United Arab Emirates: De forente arabiske emirater
     United Kingdom: Storbritannia
@@ -1022,6 +1008,12 @@ translations:
       'z:*d{z(~V2': vJUDdBqkkp
       'zSc]-^U=0=': 'td+]W)8y3S'
 target_adaptations:
+  notes.note.abkhazia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Georgia.
+    target: Utbryterstat i Georgia.
+    reason: Norwegian intentionally frames Abkhazia and South Ossetia as breakaway states in Georgia.
   notes.note.arabian-sea.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1046,6 +1038,12 @@ target_adaptations:
     expected_source: ''
     target: 'Tidligere kjent som Hviterussland. Utenriksdepartementet begynte å bruke navnet Belarus 29. mai 2022.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.cape-verde.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Cabo Verde.
+    target: Offisielt Republikken Cabo Verde.
+    reason: 'Norwegian intentionally substitutes the official long country name for the source''s alternate short name.'
   notes.note.china.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1057,6 +1055,12 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as Czechia.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.democratic-republic-of-the-congo.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Formerly Zaire.
+    target: 'Offisielt Den demokratiske republikken Kongo. Tidligere Zaïre.'
+    reason: Norwegian adds the official Democratic Republic of the Congo name to disambiguate its short answer Kongo.
   notes.note.finland.fields.field.capital-info:
     intent: adapt
     ownership: translation
@@ -1096,6 +1100,12 @@ target_adaptations:
     expected_source: ''
     target: 'Mange regner Bairiki som Kiribatis hovedstad (også Utenriksdepartementet i Norge) fordi både parlamentet og presidenten en gang hadde sete der. Siden år 2000 har parlamentet og departementer blitt spredd utover Syd-Tarawa.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.land-islands.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Autonomous region of Finland.
+    target: 'Selvstyrt og delimilitarisert øygruppe og landskap i Finland.'
+    reason: 'Norwegian intentionally enriches Åland''s description with demilitarized and archipelago/landscape status.'
   notes.note.luxembourg.fields.field.capital-info:
     intent: delete
     ownership: translation
@@ -1107,6 +1117,12 @@ target_adaptations:
     expected_source: ''
     target: 'Også kjent som Ulan Bator.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.montenegro.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Cetinje is an honorary capital.
+    target: Administrativ hovedstad. Cetinje er historisk hovedstad og presidentens tilholdssted.
+    reason: Norwegian replaces honorary-capital wording with administrative, historical, and presidential-seat facts.
   notes.note.myanmar.fields.field.capital-info:
     intent: adapt
     ownership: translation
@@ -1130,6 +1146,18 @@ target_adaptations:
     ownership: translation
     expected_source: 'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.'
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.scandinavia.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Scandinavia
+    target: Skandinavia og Norden
+    reason: Norwegian intentionally broadens the answer label to include both Skandinavia and Norden.
+  notes.note.scandinavia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Historical and cultural region in Northern Europe, which includes the countries of Denmark, Norway and Sweden, and sometimes Finland and Iceland.
+    target: Skandinavia betegner Sverige, Danmark og Norge. Norden inkluderer nabolandene Finland og Island.
+    reason: Norwegian intentionally distinguishes Skandinavia from Norden rather than preserving the source optional-membership wording.
   notes.note.sea-of-galilee.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1141,11 +1169,47 @@ target_adaptations:
     ownership: translation
     expected_source: 'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.'
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.somaliland.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Somalia.
+    target: Utbryterrepublikk i Somalia. Fungerer som selvstendig stat, men ikke anerkjent av andre.
+    reason: 'Norwegian intentionally substitutes a de facto-independence/non-recognition description for Somalia''s claim.'
+  notes.note.south-ossetia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Georgia.
+    target: Utbryterstat i Georgia.
+    reason: Norwegian intentionally frames Abkhazia and South Ossetia as breakaway states in Georgia.
+  notes.note.sri-lanka.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Colombo is often referred to as the capital but Sri Jayawardenepura Kotte, a suburb of Colombo, is the official, legislative capital.
+    target: 'Regjeringen har sete i Colombo. Sri Jayawardenepura Kotte (kalt Kotte) er en forstad til Colombo der nasjonalforsamlingen har sete. Kotte er altså lovgivende hovedstad.'
+    reason: Norwegian intentionally expands the Sri Lanka capital explanation with government and parliament locations and the short name Kotte.
+  notes.note.svalbard.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Unincorporated internal area of Norway.
+    target: 'Norsk øygruppe.'
+    reason: Norwegian intentionally describes Svalbard geographically as a Norwegian archipelago.
+  notes.note.taiwan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by China.
+    target: 'Offisielt Republikken Kina. Folkerepublikken Kina gjør også krav på områdene.'
+    reason: 'Norwegian intentionally frames Taiwan by its official Republic of China name and explicitly attributes the competing claim to the People''s Republic of China.'
   notes.note.timor-leste.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: Also known as East Timor.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.transnistria.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Moldova.
+    target: 'Region i Moldova som er en selverklært, men ikke internasjonalt anerkjent, stat.'
+    reason: Norwegian intentionally describes Transnistria as a self-declared, internationally unrecognized region in Moldova.
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1157,6 +1221,12 @@ target_adaptations:
     expected_source: ''
     target: 'Også kjent som Asjgabat.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.ukraine.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Kiev.
+    target: 'Også kjent som Kyiv.'
+    reason: Norwegian uses Kiev as the primary capital label and therefore presents Kyiv as the alternate spelling.
   notes.note.united-kingdom.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1180,3 +1250,9 @@ target_adaptations:
     ownership: translation
     expected_source: 'Also spelled as Sana''a.'
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.zanzibar.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Semi-autonomous region of Tanzania.
+    target: Delvis selvstendig stat i Tanzania.
+    reason: Norwegian intentionally uses partial-independence/state framing for Zanzibar rather than the source semi-autonomous-region wording.

--- a/overlays/languages/nl.yaml
+++ b/overlays/languages/nl.yaml
@@ -2,7 +2,6 @@ id: overlay.translation.nl
 kind: translation
 translations:
   direct:
-    'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.': Er bestaat een dispuut over de naam tussen de aangrenzende landen. In het Koreaans wordt de zee Oostzee genoemd.
     Abkhazia: 'Abchazië'
     Addis Ababa: Addis Abeba
     Adriatic Sea: Adriatische Zee
@@ -12,7 +11,6 @@ translations:
     Albania: 'Albanië'
     Algeria: Algerije
     Also known as Burma.: Ook bekend als Birma.
-    Also known as East Timor.: Ook bekend als Timor-Leste.
     Also known as the Sea of Cortez.: 'Ook wel de Zee van Cortés genoemd.'
     American Samoa: Amerikaans Samoa
     Antigua and Barbuda: Antigua en Barbuda
@@ -73,7 +71,6 @@ translations:
     Celebes Sea: Celebeszee
     Celtic Sea: Keltische Zee
     Central African Republic: Centraal-Afrikaanse Republiek
-    Cetinje is an honorary capital.: Voormalige hoofdstad is Cetinje.
     Chad: Tsjaad
     Chile: Chili
     City of San Marino: San Marino
@@ -319,9 +316,7 @@ translations:
     While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.: 'Ondanks Dodoma de officiële hoofdstad is, is Dar es Salaam de facto de zetel van de regering.'
     'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.': Ondanks Laayoune, ook wel bekend als al-Ajoen, de verklaarde hoofdstad is, is Tifariti de feitelijke zetel van de regering.
     While Mbabane is the official, executive capital, Lobamba is the traditional, spiritual and legislative capital.: Mbabane is de bestuurlijke hoofdstad en Lobamba de traditionele koninklijke hoofdstad en wettelijke zetel.
-    While Porto-Novo is the official capital, Cotonou is the de facto seat of government.: 'Porto-Novo is de officiële hoofdstad, maar de economische hoofdstad en grootste stad van Benin is Cotonou.'
     While Sucre is the constitutional capital, La Paz is the seat of government.: Ondanks Sucre de constitutionele hoofdstad is, is La Paz de zetel van de regering.
-    While Yamoussoukro is the official capital, Abidjan is the de facto seat of government.: Abidjan was tot 1983 de hoofdstad, de meeste overheidsgebouwen en ambassades bevinden zich er nog steeds.
     White Sea: Witte Zee
     World region covering the Australian continent and most of the islands in the Pacific Ocean.: Wereldregio die het Australische continent en de meeste eilanden in de Stille Oceaan beslaat.
     Yellow Sea: Gele Zee
@@ -989,6 +984,12 @@ target_adaptations:
     expected_source: ''
     target: Ook bekend als Belarus.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.benin.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: While Porto-Novo is the official capital, Cotonou is the de facto seat of government.
+    target: 'Porto-Novo is de officiële hoofdstad, maar de economische hoofdstad en grootste stad van Benin is Cotonou.'
+    reason: 'Dutch intentionally substitutes Cotonou''s economic-capital and largest-city roles for the source de facto government-seat claim.'
   notes.note.cape-verde.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1021,6 +1022,12 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as the Gulf of Siam.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.ivory-coast.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: While Yamoussoukro is the official capital, Abidjan is the de facto seat of government.
+    target: Abidjan was tot 1983 de hoofdstad, de meeste overheidsgebouwen en ambassades bevinden zich er nog steeds.
+    reason: 'Dutch intentionally replaces the de facto-seat wording with Abidjan''s former-capital history and continuing government and embassy presence.'
   notes.note.ivory-coast.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1037,6 +1044,12 @@ target_adaptations:
     expected_source: ''
     target: Ook wel Maldiven genoemd.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.montenegro.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Cetinje is an honorary capital.
+    target: Voormalige hoofdstad is Cetinje.
+    reason: Dutch intentionally describes Cetinje as the former capital instead of an honorary capital.
   notes.note.pacific-ocean.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1049,6 +1062,18 @@ target_adaptations:
     expected_source: ''
     target: Ook wel Meer van Kinneret, Meer van Galilea of Meer van Genezareth genoemd.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sea-of-japan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.'
+    target: Er bestaat een dispuut over de naam tussen de aangrenzende landen. In het Koreaans wordt de zee Oostzee genoemd.
+    reason: 'Dutch intentionally replaces South Korea''s support claim with a Korean-language naming statement.'
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: Ook bekend als Timor-Leste.
+    reason: Dutch uses Oost-Timor as the primary answer and presents Timor-Leste as the alternate name.
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/pl.yaml
+++ b/overlays/languages/pl.yaml
@@ -2,7 +2,6 @@ id: overlay.translation.pl
 kind: translation
 translations:
   direct:
-    'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.': 'Pomiędzy państwami graniczącymi z tym morzem toczy się spór o jego nazwę, przy czym Korea Południowa opowiada się za nazwą Morze Wschodnie. KSNG opowiedziała się za nazwą Morze Japońskie.'
     Abkhazia: Abchazja
     Abu Dhabi: Abu Zabi
     Abuja: 'Abudża'
@@ -33,7 +32,6 @@ translations:
     Athens: Ateny
     Atlantic Ocean: Ocean Atlantycki
     Autonomous community of Spain.: 'Wspólnota autonomiczna Hiszpanii.'
-    Autonomous province of South Korea.: 'Terytorium autonomiczne Korei Południowej, znane także jako Cheju lub Jeju.'
     Autonomous region of Finland.: Terytorium autonomiczne Finlandii.
     Autonomous region of Italy.: 'Terytorium autonomiczne Włoch.'
     Autonomous region of Papua New Guinea.: Terytorium autonomiczne Papui-Nowej Gwinei.
@@ -89,8 +87,6 @@ translations:
     China: Chiny
     'Chișinău': 'Kiszyniów'
     City of San Marino: San Marino
-    Claimed and controlled: 'Terytorium sporne, nad którym sprawuje on władzę'
-    Claimed but not controlled: 'Terytorium sporne, nad którym nie sprawuje ona władzy'
     Colombia: Kolumbia
     Colombo is often referred to as the capital but Sri Jayawardenepura Kotte, a suburb of Colombo, is the official, legislative capital.: 'Kolombo często nazywane jest stolicą, ale Sri Dźajawardanapura Kotte, przedmieście Kolombo, jest oficjalną stolicą ustawodawczą.'
     Comoros: Komory
@@ -113,8 +109,6 @@ translations:
     Democratic Republic of the Congo: Demokratyczna Republika Konga
     Denmark: Dania
     Denmark Strait: 'Cieśnina Duńska'
-    'Disputed; claimed by Israel; Ramallah is the administrative centre.': 'Terytorium sporne z Izraelem; de facto funkcję stolicy pełni Ramallah.'
-    'Disputed; claimed by Palestine.': 'Terytorium sporne z Palestyną.'
     Djibouti: 'Dżibuti'
     Dominica: Dominika
     Dominican Republic: Dominikana
@@ -167,9 +161,6 @@ translations:
     Hudson Bay: Zatoka Hudsona
     Hungary: 'Węgry'
     Iceland: Islandia
-    Independent state claimed by Georgia.: 'Państwo nieuznawane, terytorium sporne z Gruzją.'
-    Independent state claimed by Moldova.: 'Państwo nieuznawane, terytorium sporne z Mołdawią.'
-    Independent state claimed by Somalia.: 'Państwo nieuznawane, terytorium sporne z Somalią.'
     India: Indie
     Indian Ocean: Ocean Indyjski
     Indonesia: Indonezja
@@ -260,7 +251,6 @@ translations:
     Not a sovereign country: 'Nie jest suwerennym państwem'
     Nouakchott: Nawakszut
     'Nouméa': Numea
-    'Oblast (administrative region) of the Russian Federation.': 'Eksklawa Rosji. Do 2023 r. znany w języku polskim jako obwód kaliningradzki.'
     Official capital was moved from Bujumbura to Gitega in 2019.: 'Oficjalna stolica została przeniesiona z Bużumbury z powrotem do Gitegi w 2019 roku.'
     Official capital was moved from Malabo to Ciudad de la Paz in 2026.: 'Oficjalna stolica została przeniesiona z Malabo do Ciudad de la Paz w 2026 roku.'
     'Officially Côte d''Ivoire.': 'Oficjalnie Côte d’Ivoire.'
@@ -274,9 +264,6 @@ translations:
     Papua New Guinea: Papua-Nowa Gwinea
     Paraguay: Paragwaj
     Paris: 'Paryż'
-    Partially recognised state claimed by China.: 'Częściowo uznane państwo, terytorium sporne z Chinami.'
-    Partially recognised state claimed by Morocco. Also known as Western Sahara.: 'Częściowo uznane państwo, terytorium sporne z Marokiem. Znana także jako Saharyjska Arabska Republika Demokratyczna.'
-    Partially recognised state claimed by Serbia.: 'Państwo częściowo uznane, terytorium sporne z Serbią.'
     Persian Gulf: Zatoka Perska
     Philippine Sea: 'Morze Filipińskie'
     Philippines: Filipiny
@@ -299,7 +286,6 @@ translations:
     Rome: Rzym
     Russia: Rosja
     'Réunion': Reunion
-    Sahrawi Arab Democratic Republic: Sahara Zachodnia
     Saint Kitts and Nevis: Saint Kitts i Nevis
     Saint Martin: Saint-Martin
     Saint Vincent and the Grenadines: Saint Vincent i Grenadyny
@@ -978,6 +964,12 @@ translations:
       'z:*d{z(~V2': 'kBb;v^=11('
       'zSc]-^U=0=': 'O?:STIyrxP'
 target_adaptations:
+  notes.note.abkhazia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Georgia.
+    target: 'Państwo nieuznawane, terytorium sporne z Gruzją.'
+    reason: Polish localization describes Abkhazia and South Ossetia as unrecognised states and territories disputed with Georgia.
   notes.note.arctic-ocean.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -999,6 +991,36 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as Gulf of Makran.
     reason: legacy localized decks intentionally leave the untranslated source detail blank
+  notes.note.israel.fields.field.capital-hint:
+    intent: adapt
+    ownership: translation
+    expected_source: Claimed and controlled
+    target: 'Terytorium sporne, nad którym sprawuje on władzę'
+    reason: Polish localization frames the Israel hint as disputed territory under Israeli control.
+  notes.note.israel.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Disputed; claimed by Palestine.'
+    target: 'Terytorium sporne z Palestyną.'
+    reason: Polish localization frames the claim as a territorial dispute with Palestine.
+  notes.note.jeju.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Autonomous province of South Korea.
+    target: 'Terytorium autonomiczne Korei Południowej, znane także jako Cheju lub Jeju.'
+    reason: Polish localization adds the Cheju and Jeju naming variants and describes Jeju as an autonomous territory.
+  notes.note.kaliningrad-oblast.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Oblast (administrative region) of the Russian Federation.'
+    target: 'Eksklawa Rosji. Do 2023 r. znany w języku polskim jako obwód kaliningradzki.'
+    reason: Polish localization follows the 2023 Polish naming recommendation, identifies the exclave, and records the former Polish name.
+  notes.note.kosovo.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Serbia.
+    target: 'Państwo częściowo uznane, terytorium sporne z Serbią.'
+    reason: 'Polish localization frames Serbia''s claim as a territorial dispute with Serbia.'
   notes.note.luxembourg.fields.field.capital-info:
     intent: delete
     ownership: translation
@@ -1016,23 +1038,77 @@ target_adaptations:
     expected_source: ''
     target: 'Znany także jako Pacyfik.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.palestine.fields.field.capital-hint:
+    intent: adapt
+    ownership: translation
+    expected_source: Claimed but not controlled
+    target: 'Terytorium sporne, nad którym nie sprawuje ona władzy'
+    reason: Polish localization frames the Palestine hint as disputed territory outside Palestinian control.
+  notes.note.palestine.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Disputed; claimed by Israel; Ramallah is the administrative centre.'
+    target: 'Terytorium sporne z Izraelem; de facto funkcję stolicy pełni Ramallah.'
+    reason: Polish localization frames the status as a dispute with Israel and describes Ramallah as the de facto capital.
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Sahrawi Arab Democratic Republic
+    target: Sahara Zachodnia
+    reason: Polish localization uses Western Sahara as the primary label and SADR as its alternate name.
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Morocco. Also known as Western Sahara.
+    target: 'Częściowo uznane państwo, terytorium sporne z Marokiem. Znana także jako Saharyjska Arabska Republika Demokratyczna.'
+    reason: 'Polish localization uses Western Sahara as the primary label, reverses SADR into the alternate name, and frames Morocco''s claim as a dispute.'
   notes.note.sea-of-galilee.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'Znane także jako Jezioro Galilejskie lub Genezaret.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sea-of-japan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.'
+    target: 'Pomiędzy państwami graniczącymi z tym morzem toczy się spór o jego nazwę, przy czym Korea Południowa opowiada się za nazwą Morze Wschodnie. KSNG opowiedziała się za nazwą Morze Japońskie.'
+    reason: 'Polish localization adds the KSNG recommendation for the Polish name Morze Japońskie.'
+  notes.note.somaliland.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Somalia.
+    target: 'Państwo nieuznawane, terytorium sporne z Somalią.'
+    reason: Polish localization describes Somaliland as an unrecognised state and territory disputed with Somalia.
   notes.note.south-africa.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'Znana także jako RPA (Republika Południowej Afryki).'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.south-ossetia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Georgia.
+    target: 'Państwo nieuznawane, terytorium sporne z Gruzją.'
+    reason: Polish localization describes Abkhazia and South Ossetia as unrecognised states and territories disputed with Georgia.
+  notes.note.taiwan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by China.
+    target: 'Częściowo uznane państwo, terytorium sporne z Chinami.'
+    reason: 'Polish localization frames China''s claim as a territorial dispute with China.'
   notes.note.timor-leste.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: Also known as East Timor.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.transnistria.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Independent state claimed by Moldova.
+    target: 'Państwo nieuznawane, terytorium sporne z Mołdawią.'
+    reason: Polish localization describes Transnistria as an unrecognised state and territory disputed with Moldova.
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/pt.yaml
+++ b/overlays/languages/pt.yaml
@@ -343,7 +343,6 @@ translations:
     Russia: 'Rússia'
     Rwanda: Ruanda
     'Réunion': 'Reunião'
-    Sahrawi Arab Democratic Republic: 'República Árabe Saaraui Democrática (RASD)'
     Saint Kitts and Nevis: 'São Cristóvão e Névis'
     Saint Lucia: 'Santa Lúcia'
     Saint Martin: 'São Martinho (França)'
@@ -1063,6 +1062,12 @@ target_adaptations:
     expected_source: ''
     target: 'Não é um Estado soberano'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Sahrawi Arab Democratic Republic
+    target: 'República Árabe Saaraui Democrática (RASD)'
+    reason: Portuguese intentionally appends the acronym RASD to the main country label while the embedded reference uses the unexpanded name.
   notes.note.timor-leste.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/ru.yaml
+++ b/overlays/languages/ru.yaml
@@ -19,10 +19,7 @@ translations:
     Algiers: 'Алжир'
     Alofi: 'Алофи'
     Also known as Burma.: 'Также известна как Бирма.'
-    Also known as Cabo Verde.: 'Ранее известна как Острова Зелëного Мыса.'
     Also known as Czechia.: 'Известна также как Чехия.'
-    Also known as East Timor.: 'Также известен как Тимор-Лешти.'
-    Also known as the Gulf of Siam.: 'Также известен как Тайландский залив.'
     Also known as the Sea of Cortez.: 'Также известное как Кортезское море.'
     American Samoa: 'Американское Самоа'
     Amman: 'Амман'
@@ -163,7 +160,6 @@ translations:
     Denmark Strait: 'Датский пролив'
     Dhaka: 'Дакка'
     Dili: 'Дили'
-    'Disputed; claimed by Israel; Ramallah is the administrative centre.': 'Заявленная столица; оспаривается Израилем; Рамалла - административный центр.'
     'Disputed; claimed by Palestine.': 'Спорный; требует Палестина.'
     Djibouti: 'Джибути'
     Dodoma: 'Додома'
@@ -382,10 +378,8 @@ translations:
     'Nukuʻalofa': 'Нукуалофа'
     Nuuk: 'Нуук'
     'Oblast (administrative region) of the Russian Federation.': 'Область (административный район) Российской Федерации.'
-    Oceania: 'Австралия и Океания'
     Official capital was moved from Bujumbura to Gitega in 2019.: 'Официальная столица была перенесена из Бужумбуры в Гитегу в 2019 году.'
     Official capital was moved from Malabo to Ciudad de la Paz in 2026.: 'Официальная столица была перенесена из Малабо в Сьюдад-де-ла-Пас в 2026 году.'
-    'Officially Côte d''Ivoire.': 'Ранее известно как Берег Слоновой Кости.'
     Officially Luxembourg.: 'Официально Люксембург.'
     Oman: 'Оман'
     Oranjestad: 'Ораньестад'
@@ -555,7 +549,6 @@ translations:
     Uganda: 'Уганда'
     Ukraine: 'Украина'
     Ulaanbaatar: 'Улан-Батор'
-    Unincorporated internal area of Norway.: 'Также известен как Свальбард. Неинкорпорированная внутренняя территория Норвегии.'
     Unincorporated territory of the United States.: 'Неинкорпорированная территория Соединенных Штатов.'
     United Arab Emirates: 'Объединенные Арабские Эмираты'
     United Kingdom: 'Великобритания'
@@ -1010,6 +1003,12 @@ translations:
       'z:*d{z(~V2': 'fs]5;0c;}B'
       'zSc]-^U=0=': 'hpvj)-!USf'
 target_adaptations:
+  notes.note.cape-verde.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Cabo Verde.
+    target: 'Ранее известна как Острова Зелëного Мыса.'
+    reason: 'Russian localization records the historical Russian name Острова Зелëного Мыса instead of presenting Cabo Verde as an alternate name.'
   notes.note.english-channel.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1027,23 +1026,59 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as Gulf of Makran.
     reason: legacy localized decks intentionally leave the untranslated source detail blank
+  notes.note.gulf-of-thailand.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as the Gulf of Siam.
+    target: 'Также известен как Тайландский залив.'
+    reason: 'Russian localization uses Сиамский залив as the primary label and reverses Тайландский залив into the alternate name.'
+  notes.note.ivory-coast.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Officially Côte d''Ivoire.'
+    target: 'Ранее известно как Берег Слоновой Кости.'
+    reason: 'Russian localization records Берег Слоновой Кости as the former Russian name instead of restating the official name.'
   notes.note.namibia.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'Ранее известна как Юго-Западная Африка'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.oceania.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Oceania
+    target: 'Австралия и Океания'
+    reason: 'Russian school-geography localization labels the region Австралия и Океания, explicitly including Australia.'
   notes.note.oceania.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: World region covering the Australian continent and most of the islands in the Pacific Ocean.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.palestine.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Disputed; claimed by Israel; Ramallah is the administrative centre.'
+    target: 'Заявленная столица; оспаривается Израилем; Рамалла - административный центр.'
+    reason: Russian localization adds declared-capital framing and describes the status as disputed by Israel.
   notes.note.sea-of-galilee.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'Также известно как Тивериадское озеро'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.svalbard.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Unincorporated internal area of Norway.
+    target: 'Также известен как Свальбард. Неинкорпорированная внутренняя территория Норвегии.'
+    reason: 'Russian localization adds Свальбард as an alternate name for primary label Шпицберген.'
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: 'Также известен как Тимор-Лешти.'
+    reason: 'Russian localization uses Восточный Тимор as the primary label and reverses Тимор-Лешти into the alternate name.'
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/sv.yaml
+++ b/overlays/languages/sv.yaml
@@ -2,7 +2,6 @@ id: overlay.translation.sv
 kind: translation
 translations:
   direct:
-    'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.': 'Sydkorea förespråkar namnet Östhavet, Nordkorea Ostkoreanska havet.'
     Abkhazia: Abchazien
     Addis Ababa: Addis Abeba
     Adriatic Sea: Adriatiska havet
@@ -13,7 +12,6 @@ translations:
     Algeria: Algeriet
     Algiers: Alger
     Also known as Burma.: 'Även känt som Burma.'
-    Also known as East Timor.: 'Även känt som Timor-Leste.'
     Also known as the Gulf of Siam.: 'Även känd som Siambukten.'
     Also known as the Sea of Cortez.: 'Även känt som Cortez hav.'
     American Samoa: Amerikanska Samoa
@@ -30,7 +28,6 @@ translations:
     Australia: Australien
     Austria: 'Österrike'
     Autonomous community of Spain.: Spansk autonom region.
-    Autonomous province of South Korea.: 'Autonom region i Sydkorea; tidigare känd som Quelpart.'
     Autonomous region of Finland.: 'Självstyrande del av Finland.'
     Autonomous region of Italy.: Italiensk autonom region.
     Autonomous region of Papua New Guinea.: Autonom region i Papua Nya Guinea.
@@ -73,7 +70,6 @@ translations:
     City of San Marino: San Marino
     Claimed and controlled: 'Hävdas och kontrolleras'
     Claimed but not controlled: 'Påstått men inte kontrollerat'
-    Colombo is often referred to as the capital but Sri Jayawardenepura Kotte, a suburb of Colombo, is the official, legislative capital.: 'Kallas även Kotte eller Sri Jayawardenapura Kotte; Colombo refereras ofta till som huvudstad, men förorten Sri Jayawardenapura är officiell huvudstad.'
     Comoros: Komorerna
     Constituent country in the Kingdom of Denmark.: Riksdel av Danmark.
     Constituent country of the Kingdom of the Netherlands.: 'Ett av fyra länder som utgör staten Nederländerna.'
@@ -127,7 +123,6 @@ translations:
     Gulf of Thailand: Thailandviken
     Havana: Havanna
     Helsinki: Helsingfors
-    Historical and cultural region in Northern Europe, which includes the countries of Denmark, Norway and Sweden, and sometimes Finland and Iceland.: 'Skandinavien består av Sverige, Norge och Danmark. Norden inkluderar även Finland och Island, och utomskandinaviska områden som Svalbard och Grönland. '
     Hong Kong: Hongkong
     Hungary: Ungern
     Iceland: Island
@@ -147,7 +142,6 @@ translations:
     Kathmandu: Katmandu
     Kazakhstan: Kazakstan
     Known as Nur-Sultan between 2019 and 2022: Hette Nur-Sultan mellan 2019 och 2022
-    Known as Swaziland until 2018.: 'Även känt som Eswatini.'
     Kuwait City: Kuwait
     Kyiv: Kiev
     Kyrgyzstan: Kirgizistan
@@ -175,7 +169,6 @@ translations:
     Moscow: Moskva
     Mozambique: 'Moçambique'
     Muscat: Muskat
-    'Nauru has no official capital; the Yaren District is the de facto capital.': 'Nauru saknar städer, Yaren är de facto huvudort.'
     Netherlands: 'Nederländerna'
     New Caledonia: Nya Kaledonien
     New Zealand: Nya Zeeland
@@ -191,7 +184,6 @@ translations:
     Norwegian Sea: Norska havet
     Not a sovereign country: 'Ej suverän stat'
     'Nukuʻalofa': 'Nuku''alofa'
-    'Oblast (administrative region) of the Russian Federation.': 'Även känt som Ryska Östpreussen.'
     Oceania: Oceanien
     Official capital was moved from Bujumbura to Gitega in 2019.: 'Tidigare känt som Kitega; flyttat från Bujumbura i slutet av 2018.'
     Official capital was moved from Malabo to Ciudad de la Paz in 2026.: 'Flyttat från Malabo i 2026.'
@@ -199,7 +191,6 @@ translations:
     Palestine: Palestina
     Papua New Guinea: Papua Nya Guinea
     Partially recognised state claimed by China.: 'Delvis erkänd stat, görs anspråk på av Kina.'
-    Partially recognised state claimed by Morocco. Also known as Western Sahara.: 'Även känt som Västsahariska republiken.'
     Partially recognised state claimed by Serbia.: 'Delvis erkänd stat, görs anspråk på av Serbien.'
     Persian Gulf: Persiska viken
     Philippine Sea: 'Filippinska sjön'
@@ -277,7 +268,6 @@ translations:
     Turks and Caicos Islands: 'Turks- och Caicosöarna'
     Ukraine: Ukraina
     Ulaanbaatar: Ulan Bator
-    Unincorporated internal area of Norway.: 'Norsk ögrupp.'
     Unincorporated territory of the United States.: 'Amerikanskt icke-inkorporerat område.'
     United Arab Emirates: 'Förenade Arabemiraten'
     United Kingdom: Storbritannien
@@ -288,11 +278,9 @@ translations:
     Warsaw: Warszawa
     While Amsterdam is the official capital, The Hague is the seat of the executive and legislative branches.: 'Haag är administrativ huvudstad.'
     While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.: 'Dar es-Salaam är de facto administrativ huvudstad.'
-    'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.': 'Stavas även al-''Ayun, El Aaiún; Tifariti är de facto säte för parlamentet.'
     While Mbabane is the official, executive capital, Lobamba is the traditional, spiritual and legislative capital.: 'Lobamba är traditionell och lagstiftande huvudstad.'
     While Porto-Novo is the official capital, Cotonou is the de facto seat of government.: 'Cotonou är administrativ huvudstad.'
     While Sucre is the constitutional capital, La Paz is the seat of government.: 'La Paz är säte för regeringen.'
-    While Yamoussoukro is the official capital, Abidjan is the de facto seat of government.: 'Stavas även Yamassoukro; Abidjan är de facto administrativ huvudstad.'
     White Sea: Vita havet
     World region covering the Australian continent and most of the islands in the Pacific Ocean.: 'Världsdel bestående av Australien och majoriteten av öarna och ögrupperna i Stilla havet.'
     Yellow Sea: Gula havet
@@ -1056,6 +1044,12 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as Czechia.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.eswatini.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Known as Swaziland until 2018.
+    target: 'Även känt som Eswatini.'
+    reason: Swedish retains Swaziland as the primary answer and presents Eswatini as its alternate name.
   notes.note.federated-states-of-micronesia.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1067,11 +1061,29 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as Gulf of Makran.
     reason: legacy localized decks intentionally leave the untranslated source detail blank
+  notes.note.ivory-coast.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: While Yamoussoukro is the official capital, Abidjan is the de facto seat of government.
+    target: 'Stavas även Yamassoukro; Abidjan är de facto administrativ huvudstad.'
+    reason: Swedish intentionally adds the Yamassoukro spelling and uses administrative-capital wording for Abidjan.
   notes.note.ivory-coast.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: 'Officially Côte d''Ivoire.'
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.jeju.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Autonomous province of South Korea.
+    target: 'Autonom region i Sydkorea; tidigare känd som Quelpart.'
+    reason: 'Swedish intentionally adds Jeju''s former name Quelpart.'
+  notes.note.kaliningrad-oblast.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Oblast (administrative region) of the Russian Federation.'
+    target: 'Även känt som Ryska Östpreussen.'
+    reason: 'Swedish intentionally replaces the administrative classification with the localized nickname Ryska Östpreussen.'
   notes.note.luxembourg.fields.field.capital-info:
     intent: delete
     ownership: translation
@@ -1089,6 +1101,12 @@ target_adaptations:
     expected_source: ''
     target: 'Stavas även Nay Pyi Taw.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.nauru.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Nauru has no official capital; the Yaren District is the de facto capital.'
+    target: 'Nauru saknar städer, Yaren är de facto huvudort.'
+    reason: Swedish intentionally replaces the official-capital statement with a no-cities and de facto main-locality description.
   notes.note.persian-gulf.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1107,12 +1125,54 @@ target_adaptations:
     expected_source: ''
     target: Formellt Republiken Kongo.
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sahrawi-arab-democratic-republic.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.'
+    target: 'Stavas även al-''Ayun, El Aaiún; Tifariti är de facto säte för parlamentet.'
+    reason: Swedish intentionally foregrounds alternate spellings and identifies Tifariti as the de facto parliamentary seat.
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Morocco. Also known as Western Sahara.
+    target: 'Även känt som Västsahariska republiken.'
+    reason: Swedish intentionally replaces recognition and Moroccan-claim wording with a localized alternate republic name.
+  notes.note.scandinavia.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Historical and cultural region in Northern Europe, which includes the countries of Denmark, Norway and Sweden, and sometimes Finland and Iceland.
+    target: 'Skandinavien består av Sverige, Norge och Danmark. Norden inkluderar även Finland och Island, och utomskandinaviska områden som Svalbard och Grönland. '
+    reason: Swedish intentionally distinguishes Skandinavien from Norden and adds Svalbard and Greenland to the Nordic description.
   notes.note.sea-of-galilee.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: 'Även känd som Galileiska sjön och Tiberiassjön.'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sea-of-japan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.'
+    target: 'Sydkorea förespråkar namnet Östhavet, Nordkorea Ostkoreanska havet.'
+    reason: Swedish intentionally contrasts South and North Korean preferred names instead of translating only the source South Korean support statement.
+  notes.note.sri-lanka.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Colombo is often referred to as the capital but Sri Jayawardenepura Kotte, a suburb of Colombo, is the official, legislative capital.
+    target: 'Kallas även Kotte eller Sri Jayawardenapura Kotte; Colombo refereras ofta till som huvudstad, men förorten Sri Jayawardenapura är officiell huvudstad.'
+    reason: Swedish intentionally adds Kotte aliases and uses a localized summary of Sri Lanka capital relationship.
+  notes.note.svalbard.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Unincorporated internal area of Norway.
+    target: 'Norsk ögrupp.'
+    reason: Swedish intentionally describes Svalbard geographically as a Norwegian archipelago.
+  notes.note.timor-leste.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as East Timor.
+    target: 'Även känt som Timor-Leste.'
+    reason: 'Swedish uses Östtimor as the primary answer and presents Timor-Leste as the alternate name.'
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/zh-tw.yaml
+++ b/overlays/languages/zh-tw.yaml
@@ -2,7 +2,6 @@ id: overlay.translation.zh-tw
 kind: translation
 translations:
   direct:
-    Abkhazia: '阿布哈茲共和國 (Abkhazia)'
     Abu Dhabi: '阿布達比 (Abu Dhabi)'
     Abuja: '阿布加 (Abuja)'
     Accra: '阿克拉 (Accra)'
@@ -36,7 +35,6 @@ translations:
     Arctic Ocean: '北冰洋 (Arctic Ocean)'
     Argentina: '阿根廷 (Argentina)'
     Armenia: '亞美尼亞 (Armenia)'
-    Aruba: '荷屬阿魯巴 (Aruba)'
     Ashgabat: '阿什哈巴特 (Ashgabat)'
     Asia: '亞洲 (Asia)'
     Asmara: '阿斯馬拉 (Asmara)'
@@ -122,7 +120,6 @@ translations:
     Caspian Sea: '裏海 (Caspian Sea)'
     Castries: '卡斯翠 (Castries)'
     Cayman Islands: '開曼群島 (Cayman Islands)'
-    Celebes Sea: '西里伯斯海(蘇拉威西海) (Celebes Sea)'
     Celtic Sea: '凱爾特海 (Celtic Sea)'
     Central African Republic: '中非共和國 (Central African Republic)'
     Cetinje is an honorary capital.: '策提涅是歷史首都。'
@@ -401,9 +398,6 @@ translations:
     Paraguay: '巴拉圭 (Paraguay)'
     Paramaribo: '巴拉馬利波 (Paramaribo)'
     Paris: '巴黎 (Paris)'
-    Partially recognised state claimed by China.: '中國宣稱擁有該地區主權，但僅有部分國家承認。'
-    Partially recognised state claimed by Morocco. Also known as Western Sahara.: '摩洛哥宣稱擁有該地區主權，但僅有部分國家承認。又稱為西撒哈拉。'
-    Partially recognised state claimed by Serbia.: '塞爾維亞宣稱擁有該地區主權，但僅有部分國家承認。'
     Persian Gulf: '波斯灣 (Persian Gulf)'
     Peru: '祕魯 (Peru)'
     Philippine Sea: '菲律賓海 (Philippine Sea)'
@@ -417,7 +411,6 @@ translations:
     Port Vila: '維拉港 (Port Vila)'
     Port of Spain: '西班牙港 (Port of Spain)'
     Port-au-Prince: '太子港 (Port-au-Prince)'
-    Porto-Novo: '新港 (Porto-Novo)'
     Portugal: '葡萄牙 (Portugal)'
     Prague: '布拉格 (Prague)'
     Praia: '培亞 (Praia)'
@@ -440,7 +433,6 @@ translations:
     Russia: '俄羅斯 (Russia)'
     Rwanda: '盧安達 (Rwanda)'
     'Réunion': '留尼旺島 (Réunion)'
-    Sahrawi Arab Democratic Republic: '撒拉威阿拉伯民主共和國(西薩哈拉) (Sahrawi Arab Democratic Republic)'
     Saint Kitts and Nevis: '聖克里斯多福及尼維斯聯邦 (Saint Kitts and Nevis)'
     Saint Lucia: '聖露西亞 (Saint Lucia)'
     Saint Martin: '聖馬丁 (Saint Martin)'
@@ -469,14 +461,12 @@ translations:
     Sicily: '西西里島 (Sicily)'
     Sierra Leone: '獅子山 (Sierra Leone)'
     Singapore: '新加坡 (Singapore)'
-    Sint Maarten: '荷屬聖馬丁 (Sint Maarten)'
     Skopje: '斯科普里 (Skopje)'
     Slovakia: '斯洛伐克 (Slovakia)'
     Slovenia: '斯洛維尼亞 (Slovenia)'
     Sofia: '索菲亞 (Sofia)'
     Solomon Islands: '索羅門群島 (Solomon Islands)'
     Somalia: '索馬利亞 (Somalia)'
-    Somaliland: '索馬利蘭共和國 (Somaliland)'
     South Africa: '南非 (South Africa)'
     'South Africa has no legally defined capital: the branches of government are split over three cities: Pretoria (executive), Cape Town (legislative) and Bloemfontein (judicial).': '南非沒有法定首都，並有三大城市:普勒托利亞(行政)、開普敦(立法)、布隆方丹(司法)。'
     South America: '南美洲 (South America)'
@@ -516,7 +506,6 @@ translations:
     'São Tomé': '聖多美 (São Tomé)'
     'São Tomé and Príncipe': '聖多美普林西比民主共和國 (São Tomé and Príncipe)'
     Taipei: '台北 (Taipei)'
-    Taiwan: '台灣(中華民國) (Taiwan)'
     Tajikistan: '塔吉克共和國 (Tajikistan)'
     Tallinn: '塔林 (Tallinn)'
     Tanzania: '坦尚尼亞 (Tanzania)'
@@ -536,7 +525,6 @@ translations:
     Togo: '多哥 (Togo)'
     Tokyo: '東京 (Tokyo)'
     Tonga: '東加 (Tonga)'
-    Transnistria: '德涅斯特河沿岸共和國 (Transnistria)'
     Trinidad and Tobago: '千里達及托巴哥 (Trinidad and Tobago)'
     Tripoli: '的黎波里 (Tripoli)'
     Tskhinvali: '茲辛瓦利 (Tskhinvali)'
@@ -1048,11 +1036,35 @@ translations:
       43c5ba66-9a65-11e8-90c9-a0481cc15658: 3d365148-83a7-4b53-8dbc-e3b183524025
       43e2586a-9a65-11e8-a777-a0481cc15658: d75ad494-71f3-4909-beda-b80ec04c7a0d
 target_adaptations:
+  notes.note.abkhazia.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Abkhazia
+    target: '阿布哈茲共和國 (Abkhazia)'
+    reason: Traditional Chinese adds explicit republic framing to the Abkhazia label.
+  notes.note.aruba.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Aruba
+    target: '荷屬阿魯巴 (Aruba)'
+    reason: Traditional Chinese adds Dutch political affiliation to the Aruba label.
+  notes.note.benin.fields.field.capital:
+    intent: adapt
+    ownership: translation
+    expected_source: Porto-Novo
+    target: '新港 (Porto-Novo)'
+    reason: Traditional Chinese replaces the capital label with the localized translated name New Port while retaining Porto-Novo parenthetically.
   notes.note.cape-verde.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: Also known as Cabo Verde.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.celebes-sea.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Celebes Sea
+    target: '西里伯斯海(蘇拉威西海) (Celebes Sea)'
+    reason: Traditional Chinese adds Sulawesi Sea as a second name.
   notes.note.czech-republic.fields.field.country-info:
     intent: delete
     ownership: translation
@@ -1079,6 +1091,12 @@ target_adaptations:
     expected_source: ''
     target: '拉巴斯正在建造來取代馬拉波成為首都。'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.kosovo.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Serbia.
+    target: '塞爾維亞宣稱擁有該地區主權，但僅有部分國家承認。'
+    reason: Traditional Chinese uses region rather than state framing for Kosovo.
   notes.note.luxembourg.fields.field.capital-info:
     intent: delete
     ownership: translation
@@ -1089,16 +1107,58 @@ target_adaptations:
     ownership: translation
     expected_source: Also known as Burma.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Sahrawi Arab Democratic Republic
+    target: '撒拉威阿拉伯民主共和國(西薩哈拉) (Sahrawi Arab Democratic Republic)'
+    reason: Traditional Chinese adds Western Sahara as an alternate geopolitical label.
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Morocco. Also known as Western Sahara.
+    target: '摩洛哥宣稱擁有該地區主權，但僅有部分國家承認。又稱為西撒哈拉。'
+    reason: Traditional Chinese uses region rather than state framing for Western Sahara.
   notes.note.sea-of-japan.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: 'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.'
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.sint-maarten.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Sint Maarten
+    target: '荷屬聖馬丁 (Sint Maarten)'
+    reason: Traditional Chinese uses a localized label that adds Dutch political affiliation.
+  notes.note.somaliland.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Somaliland
+    target: '索馬利蘭共和國 (Somaliland)'
+    reason: Traditional Chinese adds explicit republic framing to the Somaliland label.
+  notes.note.taiwan.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Taiwan
+    target: '台灣(中華民國) (Taiwan)'
+    reason: Traditional Chinese adds the politically material Republic of China state alias.
+  notes.note.taiwan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by China.
+    target: '中國宣稱擁有該地區主權，但僅有部分國家承認。'
+    reason: Traditional Chinese uses region rather than state framing for Taiwan.
   notes.note.timor-leste.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: Also known as East Timor.
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.transnistria.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Transnistria
+    target: '德涅斯特河沿岸共和國 (Transnistria)'
+    reason: Traditional Chinese uses the expanded Pridnestrovian Republic label.
   notes.note.turkey.fields.field.country-info:
     intent: delete
     ownership: translation

--- a/overlays/languages/zh.yaml
+++ b/overlays/languages/zh.yaml
@@ -2,7 +2,6 @@ id: overlay.translation.zh
 kind: translation
 translations:
   direct:
-    'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.': '日本海(Sea of Japan)的周边国家之间存在命名争议，韩国(South Korea)尤其支持东海(East Sea)的名称，中国在元朝及明朝初时期称“鲸海”。'
     Abkhazia: '阿布哈兹(Abkhazia)'
     Abu Dhabi: '阿布扎比(Abu Dhabi)'
     Abuja: '阿布贾(Abuja)'
@@ -18,11 +17,9 @@ translations:
     Algeria: '阿尔及利亚(Algeria)'
     Algiers: '阿尔及尔(Algiers)'
     Alofi: '阿洛菲(Alofi)'
-    Also known as Burma.: '缅甸在国际上公认有2种名字(Myanmar, Burma)。'
     Also known as Cabo Verde.: '也称为佛得角(Cabo Verde)。'
     Also known as Czechia.: '也被称为捷克(Czechia)。'
     Also known as East Timor.: '也称为东帝汶(Timor-Leste)。'
-    Also known as Kiev.: '基辅在国际上公认有2种名字(Kyiv, Kiev)。'
     Also known as the Gulf of Siam.: '也被称为暹罗湾(Gulf of Siam)。'
     Also known as the Sea of Cortez.: '也被称为科尔特斯海(Sea of Cortez)。'
     American Samoa: '美属萨摩亚(American Samoa)'
@@ -98,7 +95,6 @@ translations:
     Black Sea: '黑海(Black Sea)'
     'Bogotá': '波哥大(Bogotá)'
     Bolivia: '玻利维亚(Bolivia)'
-    Bosnia and Herzegovina: '波斯尼亚和黑塞哥维那(Bosnia and Herzegovina)，简称“波黑”'
     Botswana: '博茨瓦纳(Botswana)'
     Bougainville: '布干维尔(Bougainville)'
     'Brasília': '巴西利亚(Brasília)'
@@ -128,10 +124,8 @@ translations:
     Caspian Sea: '里海(Caspian Sea)'
     Castries: '卡斯特里(Castries)'
     Cayman Islands: '开曼群岛(Cayman Islands)'
-    Celebes Sea: '苏拉威西海(Celebes Sea, 亦称西里伯斯海)'
     Celtic Sea: '凯尔特海(Celtic Sea)'
     Central African Republic: '中非共和国(Central African Republic)'
-    Cetinje is an honorary capital.: '采蒂涅(Cetinje)，黑山古都和宗教、历史中心。'
     Chad: '乍得(Chad)'
     Charlotte Amalie: '夏洛特阿马利亚(Charlotte Amalie)'
     Chile: '智利(Chile)'
@@ -356,7 +350,6 @@ translations:
     Namibia: '纳米比亚(Namibia)'
     Nassau: '拿骚(Nassau)'
     Nauru: '瑙鲁(Nauru)'
-    'Nauru has no official capital; the Yaren District is the de facto capital.': '瑙鲁(Nauru)无正式首都，政府机关设在亚伦区(the Yaren District)。'
     Naypyidaw: '内比都(Naypyidaw)'
     Nepal: '尼泊尔(Nepal)'
     Netherlands: '荷兰(Netherlands)'
@@ -389,7 +382,6 @@ translations:
     Oceania: '大洋洲(Oceania)'
     Official capital was moved from Bujumbura to Gitega in 2019.: '2019 年官方首都从布琼布拉(Bujumbura)迁至基特加(Gitega)。'
     Official capital was moved from Malabo to Ciudad de la Paz in 2026.: '2026 年官方首都从马拉博(Malabo)迁至拉巴斯城(Ciudad de la Paz)。'
-    'Officially Côte d''Ivoire.': '官方名为科特迪瓦(Côte d''Ivoire), 全称科特迪瓦共和国(The Republic of Côte d''Ivoire)'
     Officially Luxembourg.: '官方称为卢森堡(Luxembourg)。'
     Oman: '阿曼(Oman)'
     Oranjestad: '奥拉涅斯塔德(Oranjestad)'
@@ -411,8 +403,6 @@ translations:
     Paraguay: '巴拉圭(Paraguay)'
     Paramaribo: '帕拉马里博(Paramaribo)'
     Paris: '巴黎(Paris)'
-    Partially recognised state claimed by Morocco. Also known as Western Sahara.: '摩洛哥(Morocco)宣称拥有主权但仅被部分国家承认的地区。'
-    Partially recognised state claimed by Serbia.: '塞尔维亚(Serbia)宣称拥有主权但仅被部分国家承认的地区。'
     Persian Gulf: '波斯湾(Persian Gulf)'
     Peru: '秘鲁(Peru)'
     Philippine Sea: '菲律宾海(Philippine Sea)'
@@ -426,7 +416,6 @@ translations:
     Port Vila: '维拉港(Port Vila)'
     Port of Spain: '西班牙港(Port of Spain)'
     Port-au-Prince: '太子港(Port-au-Prince)'
-    Porto-Novo: '波多诺伏(Porto-Novo, 也被称之为“新港”)'
     Portugal: '葡萄牙(Portugal)'
     Prague: '布拉格(Prague)'
     Praia: '普拉亚(Praia)'
@@ -487,7 +476,6 @@ translations:
     Somalia: '索马里(Somalia)'
     Somaliland: '索马里兰(Somaliland)'
     South Africa: '南非(South Africa)'
-    'South Africa has no legally defined capital: the branches of government are split over three cities: Pretoria (executive), Cape Town (legislative) and Bloemfontein (judicial).': '南非没有法定首都，政府部门分为三个城市：行政首都(中央政府所在地)为比勒陀利亚(Pretoria, 2005年起讨论改为 茨瓦内/Tshwane 但至今没有实施)，立法首都(议会所在地)为开普敦(Cape Town)，司法首都(最高法院所在地)为布隆方丹(Bloemfontein)。'
     South America: '南美洲(South America)'
     South China Sea: '南海(South China Sea)'
     South Korea: '韩国(South Korea)'
@@ -498,7 +486,6 @@ translations:
     Sovereign country: '主权国家'
     Spain: '西班牙(Spain)'
     Special Administrative Region of China.: '中国特别行政区。'
-    Sri Jayawardenepura Kotte: '斯里贾亚瓦德纳普拉科特(Sri Jayawardenepura Kotte)，亦称科特'
     Sri Lanka: '斯里兰卡(Sri Lanka)'
     'St. George''s': '圣乔治(St. George''s)'
     'St. John''s': '圣约翰(St. John''s)'
@@ -583,10 +570,8 @@ translations:
     Wellington: '惠灵顿(Wellington)'
     While Amsterdam is the official capital, The Hague is the seat of the executive and legislative branches.: '虽然阿姆斯特丹(Amsterdam)是官方首都，但海牙(Hague)是行政和立法部门的所在地。'
     While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.: '虽然多多马(Dodoma)是官方首都，但达累斯萨拉姆(Dar es Salaam)是实际政府所在地。'
-    'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.': '虽然阿尤恩(Laayoune，西班牙语称为El Aaiún，中文含义是泉水)，是官方宣称的首都，但提法里提(Tifariti)是实际政府所在地。'
     While Mbabane is the official, executive capital, Lobamba is the traditional, spiritual and legislative capital.: '姆巴巴内(Mbabane)是官方的行政首都，而洛班巴(Lobamba)是传统观念中的首都、精神首都和立法首都。'
     While Porto-Novo is the official capital, Cotonou is the de facto seat of government.: '虽然波多诺伏(Porto-Novo)是官方首都，但科托努(Cotonou)是实际政府所在地。'
-    While Sucre is the constitutional capital, La Paz is the seat of government.: '虽然苏克雷(Sucre)是宪法认定的行政首都，但拉巴斯(La Paz)是政府所在地和财政中心。'
     While Yamoussoukro is the official capital, Abidjan is the de facto seat of government.: '虽然亚穆苏克罗(Yamoussoukro)是官方首都，但阿比让(Abidjan)是实际政府所在地。'
     White Sea: '白海(White Sea)'
     Willemstad: '威廉斯塔德(Willemstad)'
@@ -1038,23 +1023,107 @@ translations:
     crowdanki:uuid:
       43c5ba66-9a65-11e8-90c9-a0481cc15658: 6c995ee1-4b62-4019-a033-de0ef8651c83
 target_adaptations:
+  notes.note.benin.fields.field.capital:
+    intent: adapt
+    ownership: translation
+    expected_source: Porto-Novo
+    target: '波多诺伏(Porto-Novo, 也被称之为“新港”)'
+    reason: Simplified Chinese adds the localized translated alias New Port.
+  notes.note.bolivia.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: While Sucre is the constitutional capital, La Paz is the seat of government.
+    target: '虽然苏克雷(Sucre)是宪法认定的行政首都，但拉巴斯(La Paz)是政府所在地和财政中心。'
+    reason: Simplified Chinese calls Sucre an administrative capital and adds La Paz as a financial center.
+  notes.note.bosnia-and-herzegovina.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Bosnia and Herzegovina
+    target: '波斯尼亚和黑塞哥维那(Bosnia and Herzegovina)，简称“波黑”'
+    reason: 'Simplified Chinese adds the localized abbreviation 波黑 to the country label.'
+  notes.note.celebes-sea.fields.field.country:
+    intent: adapt
+    ownership: translation
+    expected_source: Celebes Sea
+    target: '苏拉威西海(Celebes Sea, 亦称西里伯斯海)'
+    reason: Simplified Chinese uses Sulawesi Sea as the primary name and adds Celebes Sea as an alternate name.
   notes.note.gulf-of-oman.fields.field.country-info:
     intent: delete
     ownership: translation
     expected_source: Also known as Gulf of Makran.
     reason: legacy localized decks intentionally leave the untranslated source detail blank
+  notes.note.ivory-coast.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Officially Côte d''Ivoire.'
+    target: '官方名为科特迪瓦(Côte d''Ivoire), 全称科特迪瓦共和国(The Republic of Côte d''Ivoire)'
+    reason: 'Simplified Chinese adds the full official state name Republic of Côte d’Ivoire.'
+  notes.note.kosovo.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Serbia.
+    target: '塞尔维亚(Serbia)宣称拥有主权但仅被部分国家承认的地区。'
+    reason: Simplified Chinese uses region rather than state framing for Kosovo.
+  notes.note.montenegro.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Cetinje is an honorary capital.
+    target: '采蒂涅(Cetinje)，黑山古都和宗教、历史中心。'
+    reason: Simplified Chinese replaces honorary-capital wording with historical-capital and religious and historical-center facts.
   notes.note.myanmar.fields.field.capital-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: '缅甸于2005年11月6日首都从仰光(Yangon)迁往内比都(Naypyidaw)。'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.myanmar.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Burma.
+    target: '缅甸在国际上公认有2种名字(Myanmar, Burma)。'
+    reason: Simplified Chinese replaces the simple alias with a claim that Myanmar and Burma are two internationally recognized names.
+  notes.note.nauru.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'Nauru has no official capital; the Yaren District is the de facto capital.'
+    target: '瑙鲁(Nauru)无正式首都，政府机关设在亚伦区(the Yaren District)。'
+    reason: Simplified Chinese substitutes the location of government offices for the de facto-capital proposition.
   notes.note.netherlands.fields.field.country-info:
     intent: adapt
     ownership: translation
     expected_source: ''
     target: '现名尼德兰(Netherlands)，中文通译为荷兰(Holanda)'
     reason: 'migrated from legacy translations.target_additions; review and describe its target-language purpose'
+  notes.note.sahrawi-arab-democratic-republic.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'While Laayoune, also known as El Aaiún, is the declared capital, Tifariti is the de facto seat of government.'
+    target: '虽然阿尤恩(Laayoune，西班牙语称为El Aaiún，中文含义是泉水)，是官方宣称的首都，但提法里提(Tifariti)是实际政府所在地。'
+    reason: Simplified Chinese adds the localized etymology that Laayoune means spring.
+  notes.note.sahrawi-arab-democratic-republic.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Partially recognised state claimed by Morocco. Also known as Western Sahara.
+    target: '摩洛哥(Morocco)宣称拥有主权但仅被部分国家承认的地区。'
+    reason: Simplified Chinese uses region rather than state framing and omits the Western Sahara alias.
+  notes.note.sea-of-japan.fields.field.country-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'A naming dispute exists between the sea''s bordering countries, with South Korea notably supporting the name East Sea.'
+    target: '日本海(Sea of Japan)的周边国家之间存在命名争议，韩国(South Korea)尤其支持东海(East Sea)的名称，中国在元朝及明朝初时期称“鲸海”。'
+    reason: Simplified Chinese adds a China-specific historical name and dynasty-period proposition for the Sea of Japan.
+  notes.note.south-africa.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: 'South Africa has no legally defined capital: the branches of government are split over three cities: Pretoria (executive), Cape Town (legislative) and Bloemfontein (judicial).'
+    target: '南非没有法定首都，政府部门分为三个城市：行政首都(中央政府所在地)为比勒陀利亚(Pretoria, 2005年起讨论改为 茨瓦内/Tshwane 但至今没有实施)，立法首都(议会所在地)为开普敦(Cape Town)，司法首都(最高法院所在地)为布隆方丹(Bloemfontein)。'
+    reason: 'Simplified Chinese expands the description with institutional glosses and the Pretoria–Tshwane renaming discussion.'
+  notes.note.sri-lanka.fields.field.capital:
+    intent: adapt
+    ownership: translation
+    expected_source: Sri Jayawardenepura Kotte
+    target: '斯里贾亚瓦德纳普拉科特(Sri Jayawardenepura Kotte)，亦称科特'
+    reason: Simplified Chinese adds Kotte as a localized short alias.
   notes.note.taiwan.fields.field.country-info:
     intent: adapt
     ownership: translation
@@ -1066,6 +1135,12 @@ target_adaptations:
     ownership: translation
     expected_source: 'Also known as Türkiye'
     reason: 'migrated legacy target adaptation; review and describe its target-language purpose'
+  notes.note.ukraine.fields.field.capital-info:
+    intent: adapt
+    ownership: translation
+    expected_source: Also known as Kiev.
+    target: '基辅在国际上公认有2种名字(Kyiv, Kiev)。'
+    reason: Simplified Chinese replaces the simple alias with a claim that Kyiv and Kiev are two internationally recognized names.
   notes.note.yellow-sea.fields.field.country-info:
     intent: adapt
     ownership: translation


### PR DESCRIPTION
> Stack 9/10 · Previous: #24 · Next: #26

## Summary
- Reclassify localized semantic overrides as typed target adaptations.
- Record expected source values, ownership, intent, and rationale so future source drift is reviewable.

## Verification
- The change is output-preserving; all 100 targets verify with unchanged goldens.
