### PR TITLE
Freeze the legacy migration baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ src/note_models/templates/generated/
 Thumbs.db
 ~$*
 .idea
+
+.frontloop/

--- a/migration/brainbrew/compare_crowdanki.py
+++ b/migration/brainbrew/compare_crowdanki.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Compare two CrowdAnki export directories without serializer-order noise."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+
+MAX_DIAGNOSTICS = 20
+
+
+class InputError(ValueError):
+    pass
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _reject_constant(value):
+    raise InputError(f"non-finite JSON number {value}")
+
+
+def _unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise InputError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def load_target(root, label):
+    if not root.is_dir():
+        raise InputError(f"{label}: target directory is missing")
+    deck_path = root / "deck.json"
+    if not deck_path.is_file():
+        raise InputError(f"{label}: deck.json is missing")
+    raw = deck_path.read_bytes()
+    try:
+        deck = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, InputError) as error:
+        raise InputError(f"{label}: invalid deck.json: {error}") from error
+    if not isinstance(deck, dict):
+        raise InputError(f"{label}: deck.json must contain a top-level object")
+
+    declared = deck.get("media_files")
+    if not isinstance(declared, list) or any(type(name) is not str for name in declared):
+        raise InputError(f"{label}: media_files must be a list of strings")
+    if len(declared) != len(set(declared)):
+        raise InputError(f"{label}: media_files contains duplicate names")
+    for name in declared:
+        path = PurePosixPath(name)
+        if not name or path.is_absolute() or ".." in path.parts or "\\" in name:
+            raise InputError(f"{label}: unsafe media filename {name!r}")
+
+    media_root = root / "media"
+    if not media_root.is_dir():
+        raise InputError(f"{label}: media directory is missing")
+    actual = {
+        path.relative_to(media_root).as_posix()
+        for path in media_root.rglob("*")
+        if path.is_file()
+    }
+    expected = set(declared)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        details = []
+        if missing:
+            details.append("missing declared media: " + ", ".join(missing[:MAX_DIAGNOSTICS]))
+        if extra:
+            details.append("undeclared media: " + ", ".join(extra[:MAX_DIAGNOSTICS]))
+        raise InputError(f"{label}: " + "; ".join(details))
+
+    media = {}
+    tree_digest = hashlib.sha256()
+    for name in sorted(actual):
+        path = media_root / name
+        digest = sha256_file(path)
+        size = path.stat().st_size
+        media[name] = (size, digest)
+        tree_digest.update(name.encode("utf-8"))
+        tree_digest.update(b"\0")
+        tree_digest.update(bytes.fromhex(digest))
+    return {
+        "deck": deck,
+        "deck_size": len(raw),
+        "deck_sha256": hashlib.sha256(raw).hexdigest(),
+        "canonical_sha256": hashlib.sha256(
+            json.dumps(deck, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+        "media": media,
+        "media_tree_sha256": tree_digest.hexdigest(),
+    }
+
+
+def _render(value):
+    rendered = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return rendered if len(rendered) <= 160 else rendered[:157] + "..."
+
+
+def json_differences(left, right, path="$"):
+    differences = []
+    if type(left) is not type(right):
+        return [(path, left, right)]
+    if isinstance(left, dict):
+        for key in sorted(left.keys() | right.keys()):
+            child = f"{path}.{key}" if key.isidentifier() else f"{path}[{json.dumps(key)}]"
+            if key not in left:
+                differences.append((child, "<missing>", right[key]))
+            elif key not in right:
+                differences.append((child, left[key], "<missing>"))
+            else:
+                differences.extend(json_differences(left[key], right[key], child))
+    elif isinstance(left, list):
+        for index in range(max(len(left), len(right))):
+            child = f"{path}[{index}]"
+            if index >= len(left):
+                differences.append((child, "<missing>", right[index]))
+            elif index >= len(right):
+                differences.append((child, left[index], "<missing>"))
+            else:
+                differences.extend(json_differences(left[index], right[index], child))
+    elif left != right:
+        differences.append((path, left, right))
+    return differences
+
+
+def compare(legacy, candidate):
+    differences = json_differences(legacy["deck"], candidate["deck"])
+    for path, before, after in differences[:MAX_DIAGNOSTICS]:
+        print(f"JSON difference {path}: legacy={_render(before)} candidate={_render(after)}")
+    if differences:
+        print(f"JSON differences: {len(differences)} total")
+
+    print(
+        f"deck.json bytes: legacy size={legacy['deck_size']} sha256={legacy['deck_sha256']}; "
+        f"candidate size={candidate['deck_size']} sha256={candidate['deck_sha256']}; "
+        f"{'identical' if legacy['deck_sha256'] == candidate['deck_sha256'] else 'different'}"
+    )
+    print(
+        f"canonical JSON sha256: legacy={legacy['canonical_sha256']}; "
+        f"candidate={candidate['canonical_sha256']}"
+    )
+
+    legacy_media = legacy["media"]
+    candidate_media = candidate["media"]
+    missing = sorted(legacy_media.keys() - candidate_media.keys())
+    extra = sorted(candidate_media.keys() - legacy_media.keys())
+    changed = sorted(
+        name for name in legacy_media.keys() & candidate_media.keys()
+        if legacy_media[name] != candidate_media[name]
+    )
+    for name in missing[:MAX_DIAGNOSTICS]:
+        print(f"Media missing from candidate: {name}")
+    for name in extra[:MAX_DIAGNOSTICS]:
+        print(f"Media extra in candidate: {name}")
+    for name in changed[:MAX_DIAGNOSTICS]:
+        print(
+            f"Media changed: {name}: legacy size={legacy_media[name][0]} sha256={legacy_media[name][1]}; "
+            f"candidate size={candidate_media[name][0]} sha256={candidate_media[name][1]}"
+        )
+    print(
+        f"media: legacy count={len(legacy_media)} tree_sha256={legacy['media_tree_sha256']}; "
+        f"candidate count={len(candidate_media)} tree_sha256={candidate['media_tree_sha256']}"
+    )
+    media_difference_count = len(missing) + len(extra) + len(changed)
+    if media_difference_count:
+        print(f"Media differences: {media_difference_count} total")
+    if differences or media_difference_count:
+        print("Parity: different")
+        return 1
+    print("Parity: equal")
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("legacy", type=Path)
+    parser.add_argument("candidate", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        legacy = load_target(args.legacy, "legacy")
+        candidate = load_target(args.candidate, "candidate")
+    except (InputError, OSError) as error:
+        print(f"Input error: {error}")
+        return 2
+    return compare(legacy, candidate)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migration/brainbrew/legacy-baseline.md
+++ b/migration/brainbrew/legacy-baseline.md
@@ -1,0 +1,73 @@
+# Legacy Python Brain Brew baseline
+
+This is the immutable oracle for the Rust Brain Brew migration. It was generated from the tracked tree at UG commit `c4f044b5b4c2c0ba209ca55fe746706e6fc266de`, verified locally with:
+
+```console
+$ jj log -r c4f044b5b4c2c0ba209ca55fe746706e6fc266de --no-graph -T 'commit_id ++ "\n"'
+c4f044b5b4c2c0ba209ca55fe746706e6fc266de
+```
+
+The commands below export all 620 tracked files at that revision to a clean temporary directory, avoiding both the current task change and ignored historical outputs. No generated file below is checked in.
+
+## Reproduction environment and commands
+
+`Pipfile.lock` SHA-256: `6233b29d040f323c74a57af2e5ccc7bc87e116b6647840eae42a1a9287c0f7cf`
+
+```console
+$ revision=c4f044b5b4c2c0ba209ca55fe746706e6fc266de
+$ baseline_root=$(mktemp -d)
+$ jj file list -r "$revision" | while IFS= read -r path; do
+    mkdir -p "$baseline_root/$(dirname "$path")"
+    jj file show -r "$revision" -- "$path" > "$baseline_root/$path"
+  done
+$ cd "$baseline_root"
+$ uv python install 3.11.15
+Installed Python 3.11.15
+$ uv tool install --python 3.11.15 pipenv==2026.7.1
+Installed pipenv==2026.7.1
+$ PIPENV_VENV_IN_PROJECT=1 PIPENV_IGNORE_VIRTUALENVS=1 \
+    pipenv --python "$(uv python find 3.11.15)" sync --dev
+All dependencies are now up-to-date!
+$ pipenv run python --version
+Python 3.11.15
+$ pipenv run python -m pip show brain-brew | grep -E '^(Name|Version):'
+Name: Brain-Brew
+Version: 0.3.11
+$ pipenv run python -m pip freeze --all
+Brain-Brew==0.3.11
+pip==26.2
+PyYAML==6.0.2
+ruamel.yaml==0.18.10
+ruamel.yaml.clib==0.2.12
+setuptools==83.0.0
+yamale==6.0.0
+$ pipenv run build
+Successfully generated template files.
+Successfully built deck.
+$ pipenv run build_experimental
+Successfully generated template files.
+Successfully built deck.
+```
+
+The regular recipe produced 16 Standard and 16 Extended targets (32 total). The Experimental recipe produced 16 targets. All **48** output directories contained `deck.json`.
+
+| Family | Targets | Notes per target | Note models per target | Media per target |
+|---|---:|---:|---:|---:|
+| Standard | 16 | 323 | 1 | 550 |
+| Extended | 16 | 323 | 1 | 550 |
+| Experimental | 16 | 323 | 1 | 555 |
+
+## Representative evidence
+
+The canonical JSON digest is SHA-256 of parsed JSON serialized as UTF-8 with sorted object keys and compact separators. The media-tree digest hashes sorted `(UTF-8 relative filename, NUL, raw SHA-256 bytes)` pairs, matching `migration/brainbrew/compare_crowdanki.py`.
+
+| Target | Notes | Note models | Media | `deck.json` bytes | Raw JSON SHA-256 | Canonical JSON SHA-256 | Media-tree SHA-256 |
+|---|---:|---:|---:|---:|---|---|---|
+| `Ultimate Geography [EN]` | 323 | 1 | 550 | 228050 | `3b5c682a8500f51bc73be31501ba6670fdc5b42244c33c73d1c65bdfa93252b9` | `8a4e83a67cf2d52d797e31bde3162e5885eef6350bde815063717419235386d7` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` |
+| `Ultimate Geography [DE]` | 323 | 1 | 550 | 228500 | `c3c896877103a9861940931570e7b7431a9bd553716cebd3b9816221603296d6` | `37ea96cff26ad6b74111c2ea7fd52584717fa6aeaf194ade4ae664c11d7174a3` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` |
+| `Ultimate Geography [EN] [Experimental]` | 323 | 1 | 555 | 239189 | `c7be5e7a3af6ec72188c1f3d1682ddaab25237fb3b39647b9bc3c7a729bf7814` | `9932816f0d44d720d80359dcaa4bf3966cdb6cafa5689301196a9a4a13e679c3` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` |
+| `Ultimate Geography [DE] [Experimental]` | 323 | 1 | 555 | 239639 | `c23b8f6edc97d69443c94862f26389421c31b6b4e1fcd48346ed6849687f27c1` | `966fffb2e64d36760d8fb21ff6406b41f220e21aa83ab3b90f380e1735252b9f` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` |
+
+Each representative directory passed a self-comparison with `python migration/brainbrew/compare_crowdanki.py LEGACY_DIR LEGACY_DIR`, including exact declared-versus-present media validation.
+
+The regenerated legacy directory remains the oracle. These compact hashes prove what was observed but do not replace the later directory-to-directory parity comparison.

--- a/migration/brainbrew/test_compare_crowdanki.py
+++ b/migration/brainbrew/test_compare_crowdanki.py
@@ -1,0 +1,143 @@
+import copy
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("compare_crowdanki.py")
+
+
+class CompareCrowdAnkiTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.deck = {
+            "crowdanki_uuid": "deck-guid",
+            "deck_configurations": [{"name": "Default", "new": {"order": 1}}],
+            "media_files": ["flag.svg"],
+            "note_models": [{"crowdanki_uuid": "model-guid", "tmpls": [{"qfmt": "{{Country}}"}]}],
+            "notes": [{"guid": "note-guid", "fields": ["France", "Paris"], "tags": ["country", "eu"]}],
+        }
+        self.write_target("legacy", self.deck)
+        self.write_target("candidate", self.deck)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def write_target(self, name, deck, *, media=True, raw=None):
+        target = self.root / name
+        if target.exists():
+            shutil.rmtree(target)
+        target.mkdir()
+        (target / "deck.json").write_text(
+            raw if raw is not None else json.dumps(deck, indent=2), encoding="utf-8"
+        )
+        if media:
+            media_dir = target / "media"
+            media_dir.mkdir(exist_ok=True)
+            for filename in deck.get("media_files", []):
+                path = media_dir / filename
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(b"same media")
+        return target
+
+    def run_compare(self, legacy="legacy", candidate="candidate"):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), str(self.root / legacy), str(self.root / candidate)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+    def test_equal_and_serializer_only_difference_pass(self):
+        result = self.run_compare()
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Parity: equal", result.stdout)
+
+        reordered = dict(reversed(list(self.deck.items())))
+        self.write_target("candidate", reordered, raw=json.dumps(reordered, separators=(",", ":")))
+        result = self.run_compare()
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("deck.json bytes:", result.stdout)
+        self.assertIn("different", result.stdout)
+        self.assertIn("Parity: equal", result.stdout)
+
+    def test_semantic_identity_surfaces_fail_with_paths(self):
+        changes = [
+            ("guid", lambda deck: deck["notes"][0].update(guid="changed"), "$.notes[0].guid"),
+            ("field", lambda deck: deck["notes"][0]["fields"].__setitem__(1, "Lyon"), "$.notes[0].fields[1]"),
+            ("tags", lambda deck: deck["notes"][0]["tags"].reverse(), "$.notes[0].tags[0]"),
+            ("model", lambda deck: deck["note_models"][0]["tmpls"][0].update(qfmt="changed"), "$.note_models[0].tmpls[0].qfmt"),
+            ("configuration", lambda deck: deck["deck_configurations"][0]["new"].update(order=2), "$.deck_configurations[0].new.order"),
+            ("scalar type", lambda deck: deck["deck_configurations"][0]["new"].update(order=True), "$.deck_configurations[0].new.order"),
+            ("deck identity", lambda deck: deck.update(crowdanki_uuid="changed"), "$.crowdanki_uuid"),
+        ]
+        for label, mutate, expected_path in changes:
+            with self.subTest(label=label):
+                changed = copy.deepcopy(self.deck)
+                mutate(changed)
+                self.write_target("candidate", changed)
+                result = self.run_compare()
+                self.assertEqual(result.returncode, 1, result.stdout)
+                self.assertIn(expected_path, result.stdout)
+
+    def test_missing_and_malformed_inputs_fail_cleanly(self):
+        cases = []
+        cases.append(("target", "absent", "candidate", "target directory is missing"))
+
+        no_deck = self.root / "no-deck"
+        no_deck.mkdir()
+        cases.append(("deck", "legacy", "no-deck", "deck.json is missing"))
+
+        self.write_target("bad-json", self.deck, raw="{")
+        cases.append(("malformed", "legacy", "bad-json", "invalid deck.json"))
+
+        self.write_target("duplicate", self.deck, raw='{"media_files":[],"media_files":[]}')
+        cases.append(("duplicate key", "legacy", "duplicate", "duplicate JSON key"))
+
+        self.write_target("no-media", self.deck, media=False)
+        cases.append(("media directory", "legacy", "no-media", "media directory is missing"))
+
+        for label, legacy, candidate, message in cases:
+            with self.subTest(label=label):
+                result = self.run_compare(legacy, candidate)
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertIn(message, result.stdout)
+
+    def test_each_target_is_validated_against_declared_media(self):
+        for target in ("legacy", "candidate"):
+            (self.root / target / "media" / "flag.svg").unlink()
+        result = self.run_compare()
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("legacy: missing declared media: flag.svg", result.stdout)
+
+        self.write_target("legacy", self.deck)
+        self.write_target("candidate", self.deck)
+        (self.root / "candidate" / "media" / "extra.txt").write_bytes(b"extra")
+        result = self.run_compare()
+        self.assertEqual(result.returncode, 2, result.stdout)
+        self.assertIn("candidate: undeclared media: extra.txt", result.stdout)
+
+    def test_media_filename_and_byte_differences_fail(self):
+        changed = copy.deepcopy(self.deck)
+        changed["media_files"] = ["map.svg"]
+        self.write_target("candidate", changed)
+        result = self.run_compare()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("Media missing from candidate: flag.svg", result.stdout)
+        self.assertIn("Media extra in candidate: map.svg", result.stdout)
+
+        self.write_target("candidate", self.deck)
+        (self.root / "candidate" / "media" / "flag.svg").write_bytes(b"changed media")
+        result = self.run_compare()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("Media changed: flag.svg", result.stdout)
+        self.assertIn("sha256=", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Freeze the legacy migration baseline

**Stack:** 1 of 14  
**Bookmark:** `brainbrew/00-baseline`  
**Base:** UG `master` (`c4f044b5b4c2c0ba209ca55fe746706e6fc266de`)

## Summary

- Establish the unchanged Python Brain Brew build as the migration oracle.
- Record a version-pinned content baseline for all 48 existing targets.
- Add strict CrowdAnki comparison support for semantic JSON and media bytes.
- Keep local Frontloop state ignored and outside the stack.

## Why

Every later adoption layer needs a known-good parent. This commit deliberately changes no deck semantics; it only freezes the behavior that Rust Brain Brew must reproduce.

## Validation

- Built all 48 legacy targets.
- Confirmed 323 notes per target.
- Confirmed 550 media files for Standard/Extended and 555 for Experimental.
- Ran the focused comparator tests successfully.
- Confirmed `.frontloop/` is absent from tracked history.

These build results are locally reproduced baseline evidence; this first layer does not yet add them to GitHub Actions.
