### PR TITLE
Add separate stable note and media identities

### DIFF
--- a/migration/brainbrew/test_validate_ids.py
+++ b/migration/brainbrew/test_validate_ids.py
@@ -1,0 +1,54 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from migration.brainbrew.validate_ids import ROOT, validate
+
+
+class ValidateIdsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.main = ROOT / "src/data/main.csv"
+        cls.ids = (ROOT / "src/data/ids.csv").read_text(encoding="utf-8")
+
+    def validate_change(self, old, new):
+        self.assertEqual(self.ids.count(old), 1)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ids.csv"
+            path.write_text(self.ids.replace(old, new), encoding="utf-8")
+            validate(self.main, path)
+
+    def test_current_inventory(self):
+        self.assertEqual(validate(), (323, 227, 323, 550))
+        self.assertIn(
+            ",note.bolivia,media.flag.bolivia.blur|media.flag.bolivia,media.map.bolivia\n",
+            self.ids,
+        )
+
+    def test_rejects_changed_main_csv(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "main.csv"
+            path.write_bytes(self.main.read_bytes().replace(b"England", b"England!", 1))
+            with self.assertRaisesRegex(ValueError, "differs from the legacy source"):
+                validate(path)
+
+    def test_rejects_invalid_or_duplicate_note_ids(self):
+        with self.assertRaisesRegex(ValueError, "invalid stable ID"):
+            self.validate_change(",note.england,media.flag.england", ",note england,media.flag.england")
+        with self.assertRaisesRegex(ValueError, "stable IDs are not unique"):
+            self.validate_change(",note.scotland,media.flag.scotland", ",note.england,media.flag.scotland")
+
+    def test_rejects_media_id_or_country_drift(self):
+        with self.assertRaisesRegex(ValueError, "flag media IDs differ"):
+            self.validate_change(
+                "media.flag.bolivia.blur|media.flag.bolivia",
+                "media.flag.bolivia|media.flag.bolivia.blur",
+            )
+        with self.assertRaisesRegex(ValueError, "map media ID differs"):
+            self.validate_change("media.map.england", "media.map.england-wrong")
+        with self.assertRaisesRegex(ValueError, "country inventory differs"):
+            self.validate_change("England,note.england", "England!,note.england")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/migration/brainbrew/validate_ids.py
+++ b/migration/brainbrew/validate_ids.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate the unchanged legacy CSV and separate Rust identity inventory."""
+
+import csv
+import hashlib
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+MAIN_HEADERS = ["country", "flag", "map", "region code", "ISO", "tags"]
+ID_HEADERS = ["country", "stable_id", "flag_media_id", "map_media_id"]
+MAIN_SHA256 = "c1688b7f47950f6ab83425e58543b16f1a161c65461a7bb680cd09acc0a7e1c2"
+IMAGE_TAG = re.compile(r'<img src="([^"<>\r\n]+)" />')
+STABLE_ID = re.compile(r"note\.[a-z0-9.-]+")
+
+
+def read_csv(path, headers):
+    lines = path.read_bytes().splitlines(keepends=True)
+    if len(lines) != 324 or any(not line.endswith(b"\n") for line in lines):
+        raise ValueError(f"{path.name} must have exactly 324 LF-terminated lines")
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle, strict=True))
+    if not rows or list(rows[0]) != headers:
+        raise ValueError(f"unexpected {path.name} headers")
+    if len(rows) != 323:
+        raise ValueError(f"expected 323 {path.name} rows, found {len(rows)}")
+    return rows
+
+
+def image_names(value, row_number):
+    matches = list(IMAGE_TAG.finditer(value))
+    if "".join(match.group(0) for match in matches) != value:
+        raise ValueError(f"row {row_number} has non-canonical image HTML")
+    return [match.group(1) for match in matches]
+
+
+def flag_id(filename):
+    match = re.fullmatch(r"ug-flag-([a-z0-9_-]+?)(-blur)?\.svg", filename)
+    if not match:
+        raise ValueError(f"invalid flag filename {filename!r}")
+    media_id = f"media.flag.{match.group(1).replace('_', '-')}"
+    return media_id + (".blur" if match.group(2) else "")
+
+
+def map_id(filename):
+    match = re.fullmatch(r"ug-map-([a-z0-9_-]+)\.png", filename)
+    if not match:
+        raise ValueError(f"invalid map filename {filename!r}")
+    return f"media.map.{match.group(1).replace('_', '-')}"
+
+
+def validate(
+    main_path=ROOT / "src/data/main.csv",
+    ids_path=ROOT / "src/data/ids.csv",
+):
+    if hashlib.sha256(main_path.read_bytes()).hexdigest() != MAIN_SHA256:
+        raise ValueError("main.csv differs from the legacy source")
+    main_rows = read_csv(main_path, MAIN_HEADERS)
+    id_rows = read_csv(ids_path, ID_HEADERS)
+    if [row["country"] for row in main_rows] != [row["country"] for row in id_rows]:
+        raise ValueError("ids.csv country inventory differs from main.csv")
+
+    stable_ids = [row["stable_id"] for row in id_rows]
+    if any(STABLE_ID.fullmatch(value) is None for value in stable_ids):
+        raise ValueError("invalid stable ID")
+    if len(stable_ids) != len(set(stable_ids)):
+        raise ValueError("stable IDs are not unique")
+
+    flag_ids = []
+    map_ids = []
+    for row_number, (main, identity) in enumerate(zip(main_rows, id_rows), 2):
+        flags = image_names(main["flag"], row_number)
+        maps = image_names(main["map"], row_number)
+        typed_flags = identity["flag_media_id"].split("|") if identity["flag_media_id"] else []
+        typed_maps = [identity["map_media_id"]] if identity["map_media_id"] else []
+        if typed_flags != [flag_id(filename) for filename in flags]:
+            raise ValueError(f"row {row_number} flag media IDs differ from legacy HTML")
+        if typed_maps != [map_id(filename) for filename in maps]:
+            raise ValueError(f"row {row_number} map media ID differs from legacy HTML")
+        flag_ids.extend(typed_flags)
+        map_ids.extend(typed_maps)
+
+    all_media_ids = flag_ids + map_ids
+    if len(flag_ids) != 227 or len(map_ids) != 323 or len(set(all_media_ids)) != 550:
+        raise ValueError("identity media coverage is not exactly 227 flags and 323 maps")
+    return len(stable_ids), len(flag_ids), len(map_ids), len(all_media_ids)
+
+
+if __name__ == "__main__":
+    notes, flags, maps, media = validate()
+    print(f"Validated {notes} note IDs, {flags} flag references, {maps} maps, and {media} media IDs")

--- a/src/data/experimental-region.yaml
+++ b/src/data/experimental-region.yaml
@@ -1,0 +1,23 @@
+version: 1
+primary_table: ids
+tables:
+  ids:
+    path: ids.csv
+  main:
+    path: main.csv
+parameters: {}
+joins:
+  - left: ids.country
+    right: main.country
+    required: true
+note:
+  id: ids.stable_id
+  note_type_id: note-type.ultimate-geography
+  fields:
+    field.region-code:
+      column: main.region code
+      type: scalar
+  tags:
+    column: main.tags
+    delimiter: ', '
+  adapter_ids: {}

--- a/src/data/ids.csv
+++ b/src/data/ids.csv
@@ -1,0 +1,324 @@
+country,stable_id,flag_media_id,map_media_id
+England,note.england,media.flag.england,media.map.england
+Scotland,note.scotland,media.flag.scotland,media.map.scotland
+United Kingdom,note.united-kingdom,media.flag.united-kingdom,media.map.united-kingdom
+Northern Ireland,note.northern-ireland,,media.map.northern-ireland
+France,note.france,media.flag.france,media.map.france
+Wales,note.wales,media.flag.wales,media.map.wales
+Georgia,note.georgia,media.flag.georgia,media.map.georgia
+Germany,note.germany,media.flag.germany,media.map.germany
+Greece,note.greece,media.flag.greece,media.map.greece
+Greenland,note.greenland,media.flag.greenland,media.map.greenland
+Hungary,note.hungary,media.flag.hungary,media.map.hungary
+Albania,note.albania,media.flag.albania,media.map.albania
+Andorra,note.andorra,media.flag.andorra,media.map.andorra
+Austria,note.austria,media.flag.austria,media.map.austria
+Azerbaijan,note.azerbaijan,media.flag.azerbaijan,media.map.azerbaijan
+Belarus,note.belarus,media.flag.belarus,media.map.belarus
+Belgium,note.belgium,media.flag.belgium,media.map.belgium
+Bosnia and Herzegovina,note.bosnia-and-herzegovina,media.flag.bosnia-and-herzegovina,media.map.bosnia-and-herzegovina
+Bulgaria,note.bulgaria,media.flag.bulgaria,media.map.bulgaria
+Croatia,note.croatia,media.flag.croatia,media.map.croatia
+Czech Republic,note.czech-republic,media.flag.czech-republic,media.map.czech-republic
+Denmark,note.denmark,media.flag.denmark,media.map.denmark
+Estonia,note.estonia,media.flag.estonia,media.map.estonia
+Faroe Islands,note.faroe-islands,media.flag.faroe-islands,media.map.faroe-islands
+Finland,note.finland,media.flag.finland,media.map.finland
+Iceland,note.iceland,media.flag.iceland,media.map.iceland
+Ireland,note.ireland,media.flag.ireland,media.map.ireland
+Italy,note.italy,media.flag.italy,media.map.italy
+Latvia,note.latvia,media.flag.latvia,media.map.latvia
+Liechtenstein,note.liechtenstein,media.flag.liechtenstein,media.map.liechtenstein
+Lithuania,note.lithuania,media.flag.lithuania,media.map.lithuania
+Luxembourg,note.luxembourg,media.flag.luxembourg,media.map.luxembourg
+North Macedonia,note.north-macedonia,media.flag.north-macedonia,media.map.north-macedonia
+Malta,note.malta,media.flag.malta,media.map.malta
+Moldova,note.moldova,media.flag.moldova,media.map.moldova
+Monaco,note.monaco,media.flag.monaco,media.map.monaco
+Montenegro,note.montenegro,media.flag.montenegro,media.map.montenegro
+Netherlands,note.netherlands,media.flag.netherlands,media.map.netherlands
+Norway,note.norway,media.flag.norway,media.map.norway
+Poland,note.poland,media.flag.poland,media.map.poland
+Portugal,note.portugal,media.flag.portugal,media.map.portugal
+Romania,note.romania,media.flag.romania,media.map.romania
+Russia,note.russia,media.flag.russia,media.map.russia
+San Marino,note.san-marino,media.flag.san-marino,media.map.san-marino
+Serbia,note.serbia,media.flag.serbia,media.map.serbia
+Slovakia,note.slovakia,media.flag.slovakia,media.map.slovakia
+Slovenia,note.slovenia,media.flag.slovenia,media.map.slovenia
+Spain,note.spain,media.flag.spain,media.map.spain
+Sweden,note.sweden,media.flag.sweden,media.map.sweden
+Switzerland,note.switzerland,media.flag.switzerland,media.map.switzerland
+Turkey,note.turkey,media.flag.turkey,media.map.turkey
+Ukraine,note.ukraine,media.flag.ukraine,media.map.ukraine
+Vatican City,note.vatican-city,media.flag.vatican-city,media.map.vatican-city
+Armenia,note.armenia,media.flag.armenia,media.map.armenia
+Cyprus,note.cyprus,media.flag.cyprus,media.map.cyprus
+Kazakhstan,note.kazakhstan,media.flag.kazakhstan,media.map.kazakhstan
+Egypt,note.egypt,media.flag.egypt,media.map.egypt
+Algeria,note.algeria,media.flag.algeria,media.map.algeria
+Angola,note.angola,media.flag.angola,media.map.angola
+Benin,note.benin,media.flag.benin,media.map.benin
+Botswana,note.botswana,media.flag.botswana,media.map.botswana
+Burkina Faso,note.burkina-faso,media.flag.burkina-faso,media.map.burkina-faso
+Cameroon,note.cameroon,media.flag.cameroon,media.map.cameroon
+Burundi,note.burundi,media.flag.burundi,media.map.burundi
+Cape Verde,note.cape-verde,media.flag.cape-verde,media.map.cape-verde
+São Tomé and Príncipe,note.sao-tome-and-principe,media.flag.sao-tome-and-principe,media.map.sao-tome-and-principe
+Central African Republic,note.central-african-republic,media.flag.central-african-republic,media.map.central-african-republic
+Chad,note.chad,media.flag.chad,media.map.chad
+Equatorial Guinea,note.equatorial-guinea,media.flag.equatorial-guinea,media.map.equatorial-guinea
+Kenya,note.kenya,media.flag.kenya,media.map.kenya
+Comoros,note.comoros,media.flag.comoros,media.map.comoros
+Ivory Coast,note.ivory-coast,media.flag.ivory-coast,media.map.ivory-coast
+Democratic Republic of the Congo,note.democratic-republic-of-the-congo,media.flag.democratic-republic-of-the-congo,media.map.democratic-republic-of-the-congo
+Djibouti,note.djibouti,media.flag.djibouti,media.map.djibouti
+Guinea-Bissau,note.guinea-bissau,media.flag.guinea-bissau,media.map.guinea-bissau
+Eritrea,note.eritrea,media.flag.eritrea,media.map.eritrea
+Ethiopia,note.ethiopia,media.flag.ethiopia,media.map.ethiopia
+Gabon,note.gabon,media.flag.gabon,media.map.gabon
+The Gambia,note.the-gambia,media.flag.the-gambia,media.map.the-gambia
+Lesotho,note.lesotho,media.flag.lesotho,media.map.lesotho
+Liberia,note.liberia,media.flag.liberia,media.map.liberia
+Madagascar,note.madagascar,media.flag.madagascar,media.map.madagascar
+Malawi,note.malawi,media.flag.malawi,media.map.malawi
+Mali,note.mali,media.flag.mali,media.map.mali
+Mauritania,note.mauritania,media.flag.mauritania,media.map.mauritania
+Mauritius,note.mauritius,media.flag.mauritius,media.map.mauritius
+Morocco,note.morocco,media.flag.morocco,media.map.morocco
+Mozambique,note.mozambique,media.flag.mozambique,media.map.mozambique
+Namibia,note.namibia,media.flag.namibia,media.map.namibia
+Niger,note.niger,media.flag.niger,media.map.niger
+Nigeria,note.nigeria,media.flag.nigeria,media.map.nigeria
+Republic of the Congo,note.republic-of-the-congo,media.flag.republic-of-the-congo,media.map.republic-of-the-congo
+Rwanda,note.rwanda,media.flag.rwanda,media.map.rwanda
+Senegal,note.senegal,media.flag.senegal,media.map.senegal
+Seychelles,note.seychelles,media.flag.seychelles,media.map.seychelles
+Sierra Leone,note.sierra-leone,media.flag.sierra-leone,media.map.sierra-leone
+South Africa,note.south-africa,media.flag.south-africa,media.map.south-africa
+Sudan,note.sudan,media.flag.sudan,media.map.sudan
+Eswatini,note.eswatini,media.flag.eswatini,media.map.eswatini
+Tanzania,note.tanzania,media.flag.tanzania,media.map.tanzania
+Togo,note.togo,media.flag.togo,media.map.togo
+Tunisia,note.tunisia,media.flag.tunisia,media.map.tunisia
+Uganda,note.uganda,media.flag.uganda,media.map.uganda
+Sahrawi Arab Democratic Republic,note.sahrawi-arab-democratic-republic,media.flag.sahrawi-arab-democratic-republic,media.map.sahrawi-arab-democratic-republic
+Zambia,note.zambia,media.flag.zambia,media.map.zambia
+Zimbabwe,note.zimbabwe,media.flag.zimbabwe,media.map.zimbabwe
+Canary Islands,note.canary-islands,,media.map.canary-islands
+Afghanistan,note.afghanistan,media.flag.afghanistan,media.map.afghanistan
+Bahrain,note.bahrain,media.flag.bahrain,media.map.bahrain
+Bangladesh,note.bangladesh,media.flag.bangladesh,media.map.bangladesh
+Bhutan,note.bhutan,media.flag.bhutan,media.map.bhutan
+Brunei,note.brunei,media.flag.brunei,media.map.brunei
+China,note.china,media.flag.china,media.map.china
+Cambodia,note.cambodia,media.flag.cambodia,media.map.cambodia
+Indonesia,note.indonesia,media.flag.indonesia,media.map.indonesia
+India,note.india,media.flag.india,media.map.india
+Hong Kong,note.hong-kong,media.flag.hong-kong,media.map.hong-kong
+Iran,note.iran,media.flag.iran,media.map.iran
+Israel,note.israel,media.flag.israel,media.map.israel
+Iraq,note.iraq,media.flag.iraq,media.map.iraq
+South Korea,note.south-korea,media.flag.south-korea,media.map.south-korea
+North Korea,note.north-korea,media.flag.north-korea,media.map.north-korea
+Jordan,note.jordan,media.flag.jordan,media.map.jordan
+Japan,note.japan,media.flag.japan,media.map.japan
+Lebanon,note.lebanon,media.flag.lebanon,media.map.lebanon
+Laos,note.laos,media.flag.laos,media.map.laos
+Kyrgyzstan,note.kyrgyzstan,media.flag.kyrgyzstan,media.map.kyrgyzstan
+Kuwait,note.kuwait,media.flag.kuwait,media.map.kuwait
+Myanmar,note.myanmar,media.flag.myanmar,media.map.myanmar
+Mongolia,note.mongolia,media.flag.mongolia,media.map.mongolia
+Maldives,note.maldives,media.flag.maldives,media.map.maldives
+Malaysia,note.malaysia,media.flag.malaysia,media.map.malaysia
+Oman,note.oman,media.flag.oman,media.map.oman
+Nepal,note.nepal,media.flag.nepal-nobox,media.map.nepal
+Palestine,note.palestine,media.flag.palestine,media.map.palestine
+Pakistan,note.pakistan,media.flag.pakistan,media.map.pakistan
+Qatar,note.qatar,media.flag.qatar,media.map.qatar
+Saudi Arabia,note.saudi-arabia,media.flag.saudi-arabia,media.map.saudi-arabia
+Singapore,note.singapore,media.flag.singapore,media.map.singapore
+Syria,note.syria,media.flag.syria,media.map.syria
+Taiwan,note.taiwan,media.flag.taiwan,media.map.taiwan
+Sri Lanka,note.sri-lanka,media.flag.sri-lanka,media.map.sri-lanka
+Tajikistan,note.tajikistan,media.flag.tajikistan,media.map.tajikistan
+Thailand,note.thailand,media.flag.thailand,media.map.thailand
+Timor-Leste,note.timor-leste,media.flag.timor-leste,media.map.timor-leste
+United Arab Emirates,note.united-arab-emirates,media.flag.united-arab-emirates,media.map.united-arab-emirates
+Turkmenistan,note.turkmenistan,media.flag.turkmenistan,media.map.turkmenistan
+Yemen,note.yemen,media.flag.yemen,media.map.yemen
+Vietnam,note.vietnam,media.flag.vietnam,media.map.vietnam
+Uzbekistan,note.uzbekistan,media.flag.uzbekistan,media.map.uzbekistan
+Fiji,note.fiji,media.flag.fiji,media.map.fiji
+Papua New Guinea,note.papua-new-guinea,media.flag.papua-new-guinea,media.map.papua-new-guinea
+Australia,note.australia,media.flag.australia,media.map.australia
+Solomon Islands,note.solomon-islands,media.flag.solomon-islands,media.map.solomon-islands
+Argentina,note.argentina,media.flag.argentina,media.map.argentina
+Bolivia,note.bolivia,media.flag.bolivia.blur|media.flag.bolivia,media.map.bolivia
+Brazil,note.brazil,media.flag.brazil,media.map.brazil
+Chile,note.chile,media.flag.chile,media.map.chile
+Colombia,note.colombia,media.flag.colombia,media.map.colombia
+Ecuador,note.ecuador,media.flag.ecuador,media.map.ecuador
+Guyana,note.guyana,media.flag.guyana,media.map.guyana
+Paraguay,note.paraguay,media.flag.paraguay.blur|media.flag.paraguay,media.map.paraguay
+Peru,note.peru,media.flag.peru,media.map.peru
+Suriname,note.suriname,media.flag.suriname,media.map.suriname
+Uruguay,note.uruguay,media.flag.uruguay,media.map.uruguay
+Venezuela,note.venezuela,media.flag.venezuela,media.map.venezuela
+Cook Islands,note.cook-islands,media.flag.cook-islands,media.map.cook-islands
+Federated States of Micronesia,note.federated-states-of-micronesia,media.flag.federated-states-of-micronesia,media.map.federated-states-of-micronesia
+Guam,note.guam,media.flag.guam.blur|media.flag.guam,media.map.guam
+Vanuatu,note.vanuatu,media.flag.vanuatu,media.map.vanuatu
+Canada,note.canada,media.flag.canada,media.map.canada
+United States of America,note.united-states-of-america,media.flag.united-states-of-america,media.map.united-states-of-america
+Mexico,note.mexico,media.flag.mexico,media.map.mexico
+Puerto Rico,note.puerto-rico,media.flag.puerto-rico,media.map.puerto-rico
+Cuba,note.cuba,media.flag.cuba,media.map.cuba
+Dominican Republic,note.dominican-republic,media.flag.dominican-republic,media.map.dominican-republic
+Haiti,note.haiti,media.flag.haiti,media.map.haiti
+Jamaica,note.jamaica,media.flag.jamaica,media.map.jamaica
+Trinidad and Tobago,note.trinidad-and-tobago,media.flag.trinidad-and-tobago,media.map.trinidad-and-tobago
+Bermuda,note.bermuda,,media.map.bermuda
+Guadeloupe,note.guadeloupe,,media.map.guadeloupe
+The Bahamas,note.the-bahamas,media.flag.the-bahamas,media.map.the-bahamas
+Barbados,note.barbados,media.flag.barbados,media.map.barbados
+Belize,note.belize,media.flag.belize,media.map.belize
+Costa Rica,note.costa-rica,media.flag.costa-rica.blur|media.flag.costa-rica,media.map.costa-rica
+El Salvador,note.el-salvador,media.flag.el-salvador.blur|media.flag.el-salvador,media.map.el-salvador
+Guatemala,note.guatemala,media.flag.guatemala,media.map.guatemala
+Honduras,note.honduras,media.flag.honduras,media.map.honduras
+Nicaragua,note.nicaragua,media.flag.nicaragua.blur|media.flag.nicaragua,media.map.nicaragua
+Panama,note.panama,media.flag.panama,media.map.panama
+Antigua and Barbuda,note.antigua-and-barbuda,media.flag.antigua-and-barbuda,media.map.antigua-and-barbuda
+Dominica,note.dominica,media.flag.dominica,media.map.dominica
+Saint Vincent and the Grenadines,note.saint-vincent-and-the-grenadines,media.flag.saint-vincent-and-the-grenadines,media.map.saint-vincent-and-the-grenadines
+Somalia,note.somalia,media.flag.somalia,media.map.somalia
+Zanzibar,note.zanzibar,,media.map.zanzibar
+Ghana,note.ghana,media.flag.ghana,media.map.ghana
+Guinea,note.guinea,media.flag.guinea,media.map.guinea
+New Zealand,note.new-zealand,media.flag.new-zealand,media.map.new-zealand
+French Polynesia,note.french-polynesia,media.flag.french-polynesia,media.map.french-polynesia
+Philippines,note.philippines,media.flag.philippines,media.map.philippines
+Kosovo,note.kosovo,media.flag.kosovo,media.map.kosovo
+Libya,note.libya,media.flag.libya,media.map.libya
+Palau,note.palau,media.flag.palau,media.map.palau
+Saint Lucia,note.saint-lucia,media.flag.saint-lucia,media.map.saint-lucia
+Bali,note.bali,,media.map.bali
+Grenada,note.grenada,media.flag.grenada,media.map.grenada
+British Virgin Islands,note.british-virgin-islands,,media.map.british-virgin-islands
+Turks and Caicos Islands,note.turks-and-caicos-islands,,media.map.turks-and-caicos-islands
+Cayman Islands,note.cayman-islands,,media.map.cayman-islands
+Anguilla,note.anguilla,,media.map.anguilla
+Azores,note.azores,,media.map.azores
+Curaçao,note.curacao,media.flag.curacao,media.map.curacao
+French Guiana,note.french-guiana,,media.map.french-guiana
+Gibraltar,note.gibraltar,,media.map.gibraltar
+Guernsey,note.guernsey,,media.map.guernsey
+Isle of Man,note.isle-of-man,,media.map.isle-of-man
+Jersey,note.jersey,,media.map.jersey
+Kiribati,note.kiribati,media.flag.kiribati,media.map.kiribati
+Macau,note.macau,media.flag.macau,media.map.macau
+Madeira,note.madeira,,media.map.madeira
+Marshall Islands,note.marshall-islands,media.flag.marshall-islands,media.map.marshall-islands
+Nauru,note.nauru,media.flag.nauru,media.map.nauru
+New Caledonia,note.new-caledonia,media.flag.new-caledonia,media.map.new-caledonia
+Niue,note.niue,media.flag.niue,media.map.niue
+Northern Cyprus,note.northern-cyprus,media.flag.northern-cyprus,media.map.northern-cyprus
+Saint Kitts and Nevis,note.saint-kitts-and-nevis,media.flag.saint-kitts-and-nevis,media.map.saint-kitts-and-nevis
+Samoa,note.samoa,media.flag.samoa,media.map.samoa
+Somaliland,note.somaliland,media.flag.somaliland,media.map.somaliland
+South Sudan,note.south-sudan,media.flag.south-sudan,media.map.south-sudan
+Tuvalu,note.tuvalu,media.flag.tuvalu,media.map.tuvalu
+United States Virgin Islands,note.united-states-virgin-islands,media.flag.united-states-virgin-islands,media.map.united-states-virgin-islands
+Åland Islands,note.aland-islands,media.flag.aland-islands,media.map.aland-islands
+South Ossetia,note.south-ossetia,media.flag.south-ossetia,media.map.south-ossetia
+American Samoa,note.american-samoa,,media.map.american-samoa
+Northern Mariana Islands,note.northern-mariana-islands,,media.map.northern-mariana-islands
+Aruba,note.aruba,media.flag.aruba,media.map.aruba
+Abkhazia,note.abkhazia,media.flag.abkhazia,media.map.abkhazia
+Sint Maarten,note.sint-maarten,,media.map.sint-maarten
+Tonga,note.tonga,media.flag.tonga,media.map.tonga
+Transnistria,note.transnistria,media.flag.transnistria,media.map.transnistria
+Sardinia,note.sardinia,,media.map.sardinia
+Kaliningrad Oblast,note.kaliningrad-oblast,,media.map.kaliningrad-oblast
+Martinique,note.martinique,,media.map.martinique
+Java,note.java,,media.map.java
+Corsica,note.corsica,,media.map.corsica
+European Union,note.european-union,media.flag.european-union,media.map.european-union
+Gulf of Mexico,note.gulf-of-mexico,,media.map.gulf-of-mexico
+Philippine Sea,note.philippine-sea,,media.map.philippine-sea
+Southern Ocean,note.southern-ocean,,media.map.southern-ocean-nobox
+Gulf of Thailand,note.gulf-of-thailand,,media.map.gulf-of-thailand
+Micronesia,note.micronesia,,media.map.micronesia
+Pacific Ocean,note.pacific-ocean,,media.map.pacific-ocean-nobox
+Atlantic Ocean,note.atlantic-ocean,,media.map.atlantic-ocean-nobox
+Indian Ocean,note.indian-ocean,,media.map.indian-ocean-nobox
+Arctic Ocean,note.arctic-ocean,,media.map.arctic-ocean-nobox
+Hudson Bay,note.hudson-bay,,media.map.hudson-bay
+Labrador Sea,note.labrador-sea,,media.map.labrador-sea
+White Sea,note.white-sea,,media.map.white-sea
+Denmark Strait,note.denmark-strait,,media.map.denmark-strait
+Norwegian Sea,note.norwegian-sea,,media.map.norwegian-sea
+Baltic Sea,note.baltic-sea,,media.map.baltic-sea
+Celtic Sea,note.celtic-sea,,media.map.celtic-sea
+English Channel,note.english-channel,,media.map.english-channel
+Adriatic Sea,note.adriatic-sea,,media.map.adriatic-sea
+Bay of Biscay,note.bay-of-biscay,,media.map.bay-of-biscay
+Black Sea,note.black-sea,,media.map.black-sea
+Aegean Sea,note.aegean-sea,,media.map.aegean-sea
+Balkan Peninsula,note.balkan-peninsula,,media.map.balkan-peninsula
+Caspian Sea,note.caspian-sea,,media.map.caspian-sea
+Mediterranean Sea,note.mediterranean-sea,,media.map.mediterranean-sea
+East Siberian Sea,note.east-siberian-sea,,media.map.east-siberian-sea
+Bering Strait,note.bering-strait,,media.map.bering-strait
+Arabian Sea,note.arabian-sea,,media.map.arabian-sea
+Red Sea,note.red-sea,,media.map.red-sea
+Dead Sea,note.dead-sea,,media.map.dead-sea
+Bay of Bengal,note.bay-of-bengal,,media.map.bay-of-bengal
+Sea of Japan,note.sea-of-japan,,media.map.sea-of-japan
+Yellow Sea,note.yellow-sea,,media.map.yellow-sea
+Coral Sea,note.coral-sea,,media.map.coral-sea
+South China Sea,note.south-china-sea,,media.map.south-china-sea
+Tasman Sea,note.tasman-sea,,media.map.tasman-sea
+Gulf of Carpentaria,note.gulf-of-carpentaria,,media.map.gulf-of-carpentaria
+Aral Sea,note.aral-sea,,media.map.aral-sea
+Persian Gulf,note.persian-gulf,,media.map.persian-gulf
+Caribbean Sea,note.caribbean-sea,,media.map.caribbean-sea
+Gulf of California,note.gulf-of-california,,media.map.gulf-of-california
+Polynesia,note.polynesia,,media.map.polynesia
+Melanesia,note.melanesia,,media.map.melanesia
+Scandinavia,note.scandinavia,,media.map.scandinavia
+Sea of Galilee,note.sea-of-galilee,,media.map.sea-of-galilee
+Sumatra,note.sumatra,,media.map.sumatra
+Sicily,note.sicily,,media.map.sicily
+Mayotte,note.mayotte,,media.map.mayotte
+Réunion,note.reunion,,media.map.reunion
+Falkland Islands,note.falkland-islands,,media.map.falkland-islands
+Europe,note.europe,,media.map.europe-nobox
+North America,note.north-america,,media.map.north-america-nobox
+South America,note.south-america,,media.map.south-america-nobox
+Asia,note.asia,,media.map.asia-nobox
+Africa,note.africa,,media.map.africa-nobox
+Oceania,note.oceania,,media.map.oceania-nobox
+Antarctica,note.antarctica,,media.map.antarctica-nobox
+Saint Martin,note.saint-martin,,media.map.saint-martin
+Wallis and Futuna,note.wallis-and-futuna,,media.map.wallis-and-futuna
+Akrotiri and Dhekelia,note.akrotiri-and-dhekelia,,media.map.akrotiri-and-dhekelia
+Svalbard,note.svalbard,,media.map.svalbard
+Hawaii,note.hawaii,,media.map.hawaii
+Alaska,note.alaska,,media.map.alaska
+Bougainville,note.bougainville,,media.map.bougainville
+Jeju,note.jeju,,media.map.jeju
+Banda Sea,note.banda-sea,,media.map.banda-sea
+Barents Sea,note.barents-sea,,media.map.barents-sea
+Celebes Sea,note.celebes-sea,,media.map.celebes-sea
+East China Sea,note.east-china-sea,,media.map.east-china-sea
+Gulf of Alaska,note.gulf-of-alaska,,media.map.gulf-of-alaska
+Gulf of Guinea,note.gulf-of-guinea,,media.map.gulf-of-guinea
+North Sea,note.north-sea,,media.map.north-sea
+Sea of Okhotsk,note.sea-of-okhotsk,,media.map.sea-of-okhotsk
+Timor Sea,note.timor-sea,,media.map.timor-sea
+Strait of Malacca,note.strait-of-malacca,,media.map.strait-of-malacca
+Strait of Hormuz,note.strait-of-hormuz,,media.map.strait-of-hormuz
+Strait of Gibraltar,note.strait-of-gibraltar,,media.map.strait-of-gibraltar
+Gulf of Oman,note.gulf-of-oman,,media.map.gulf-of-oman

--- a/src/data/ultimate-geography.yaml
+++ b/src/data/ultimate-geography.yaml
@@ -1,0 +1,93 @@
+version: 1
+primary_table: ids
+tables:
+  ids:
+    path: ids.csv
+  main:
+    path: main.csv
+  guid:
+    path: guid.csv
+  country:
+    path: country.csv
+  country_info:
+    path: country_info.csv
+  capital:
+    path: capital.csv
+  capital_info:
+    path: capital_info.csv
+  capital_hint:
+    path: capital_hint.csv
+  flag_similarity:
+    path: flag_similarity.csv
+parameters:
+  language:
+    type: localized_column
+    default: ''
+    separator: ':'
+joins:
+  - left: ids.country
+    right: main.country
+    required: true
+  - left: ids.country
+    right: guid.country
+    required: true
+  - left: ids.country
+    right: country.country
+    required: true
+  - left: ids.country
+    right: country_info.country
+    required: false
+  - left: ids.country
+    right: capital.country
+    required: false
+  - left: ids.country
+    right: capital_info.country
+    required: false
+  - left: ids.country
+    right: capital_hint.country
+    required: false
+  - left: ids.country
+    right: flag_similarity.country
+    required: false
+note:
+  id: ids.stable_id
+  note_type_id: note-type.ultimate-geography
+  fields:
+    field.country:
+      column: country.country
+      localized_by: language
+      type: scalar
+    field.country-info:
+      column: country_info.country info
+      localized_by: language
+      type: scalar
+    field.capital:
+      column: capital.capital
+      localized_by: language
+      type: scalar
+    field.capital-info:
+      column: capital_info.capital info
+      localized_by: language
+      type: scalar
+    field.capital-hint:
+      column: capital_hint.capital hint
+      localized_by: language
+      type: scalar
+    field.flag:
+      column: ids.flag_media_id
+      type: image
+      delimiter: '|'
+    field.flag-similarity:
+      column: flag_similarity.flag similarity
+      localized_by: language
+      type: scalar
+    field.map:
+      column: ids.map_media_id
+      type: image
+  tags:
+    column: main.tags
+    delimiter: ', '
+  adapter_ids:
+    crowdanki:guid:
+      column: guid.guid
+      localized_by: language


### PR DESCRIPTION
# Add separate stable note and media identities

**Stack:** 2 of 14  
**Bookmark:** `brainbrew/01-identities`  
**Depends on:** `brainbrew/00-baseline`

## Summary

- Add `src/data/ids.csv` with 323 stable note IDs and typed flag/map media IDs, using readable ASCII transliterations for names with diacritics.
- Add Rust authoring descriptors that use `ids.csv` as the primary table and join country content explicitly.
- Keep `src/data/main.csv` byte-identical to `master`.

## Why

Stable identities belong in explicit Rust authoring data, not in legacy content columns. Separating them lets both builders coexist without rewriting the historical CSV.

## Validation

- Validated 323 unique note IDs.
- Validated 227 flag references, 323 map references, and 550 unique media IDs.
- Rebuilt all 48 legacy targets with no output change.
