### PR TITLE
Shadow English Standard with Rust Brain Brew

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -3,29 +3,93 @@ name: Integrity check
 on: [push, pull_request]
 
 jobs:
-
-  build:
+  legacy:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install legacy dependencies
+        run: |
+          python -m pip install --upgrade pipenv
+          pipenv sync --dev
+      - name: Build all legacy decks
+        run: |
+          pipenv run build
+          pipenv run build_experimental
+      - name: Preserve English Standard oracle
+        run: |
+          mkdir -p build/legacy-en-standard-artifact
+          cp -a 'build/Ultimate Geography [EN]/.' build/legacy-en-standard-artifact/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: legacy-en-standard
+          path: build/legacy-en-standard-artifact
+          if-no-files-found: error
 
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.11
+  rust-en-standard-shadow:
+    needs: legacy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Set up Rust 1.94.0
+        run: |
+          rustup toolchain install 1.94.0 --profile minimal
+          rustup default 1.94.0
+      - name: Install exact Rust Brain Brew
+        run: |
+          cargo install brainbrew \
+            --git https://github.com/jeprecated/brain-brew.git \
+            --rev 1e56a90a42be2522431cd678dfd81617eb4214a6 \
+            --locked
+          test "$(brainbrew --version)" = 'brainbrew 1.0.0-alpha.8'
+      - uses: actions/download-artifact@v4
+        with:
+          name: legacy-en-standard
+          path: build/legacy-en-standard
+      - name: Validate English Standard shadow
+        run: |
+          export PYTHONDONTWRITEBYTECODE=1
+          python -m unittest -v \
+            migration/brainbrew/test_compare_crowdanki.py \
+            migration/brainbrew/test_validate_ids.py \
+            migration/brainbrew/test_stage_media.py
+          python migration/brainbrew/validate_ids.py
+          python migration/brainbrew/stage_media.py stage
+          python migration/brainbrew/stage_media.py check
 
-    - name: Install dependencies
-      run: |
-        python3 -m pip install --upgrade pipenv
-        pipenv install
+          sha256sum brainbrew.yaml deck.yaml note-types.yaml media.yaml > /tmp/brainbrew-yaml.sha256
+          brainbrew fmt brainbrew.yaml
+          brainbrew fmt deck.yaml
+          brainbrew fmt note-types.yaml
+          brainbrew fmt media.yaml
+          sha256sum --check /tmp/brainbrew-yaml.sha256
 
-    - name: Validate regular & extended decks
-      run: |
-        pipenv run build
+          brainbrew targets --manifest brainbrew.yaml --json > build/brainbrew-targets.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          targets = json.loads(Path('build/brainbrew-targets.json').read_text())['targets']
+          assert [target['name'] for target in targets] == ['en-standard'], targets
+          PY
 
-    - name: Validate experimental deck
-      run: |
-        pipenv run build_experimental
-
-      # TODO: Validate the csv file structure
+          brainbrew validate --manifest brainbrew.yaml --target en-standard
+          mkdir -p build/brainbrew
+          brainbrew compose --manifest brainbrew.yaml --target en-standard \
+            --out build/brainbrew/en-standard.yaml
+          brainbrew verify --manifest brainbrew.yaml --target en-standard \
+            --media-root build/brainbrew-media/standard
+          brainbrew explain --manifest brainbrew.yaml --target en-standard --json \
+            > build/brainbrew/en-standard-explain.json
+          brainbrew translations --manifest brainbrew.yaml --target en-standard --json \
+            > build/brainbrew/en-standard-translations.json
+          brainbrew export crowdanki --manifest brainbrew.yaml --target en-standard \
+            --media-root build/brainbrew-media/standard \
+            --out build/brainbrew/crowdanki/en-standard
+          python migration/brainbrew/compare_crowdanki.py \
+            build/legacy-en-standard \
+            build/brainbrew/crowdanki/en-standard

--- a/brainbrew.yaml
+++ b/brainbrew.yaml
@@ -1,0 +1,31 @@
+package:
+  id: anki-geo.ultimate-geography
+  version: 1.0.0
+base: deck.yaml
+overlays: {}
+targets:
+  en-standard:
+    overlays: []
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/en-standard
+languages:
+  en:
+    display_name: English
+    source: true
+    primary_target: standard
+    targets:
+      standard: en-standard
+translation_profile:
+  structural_fields:
+    - field.flag
+    - field.map
+  metadata_paths:
+    - 'deck.*'
+    - 'note_types.*'
+    - 'notes.*.tags.*'
+  metadata_exclude_paths:
+    - 'deck.adapter_ids.*'
+    - 'note_types.*.adapter_ids.*'
+    - 'note_types.*.card_templates.*.adapter_ids.*'
+    - 'notes.*.adapter_ids.*'

--- a/deck.yaml
+++ b/deck.yaml
@@ -1,0 +1,15 @@
+deck:
+  id: deck.ultimate-geography
+  name: Ultimate Geography
+  description: !include src/headers/desc.html
+  adapter_ids:
+    crowdanki:deck_config_name: Ultimate Geography
+    crowdanki:deck_config_uuid: 43d37fac-9a65-11e8-9cc5-a0481cc15658
+    crowdanki:uuid: 43c5ba66-9a65-11e8-90c9-a0481cc15658
+note_types: !include note-types.yaml
+notes: !csv
+  descriptor: src/data/ultimate-geography.yaml
+  parameters:
+    language: ''
+media: !include media.yaml
+tombstones: []

--- a/media.yaml
+++ b/media.yaml
@@ -1,0 +1,1650 @@
+media.flag.abkhazia:
+  path: ug-flag-abkhazia.svg
+  sha256: b23c754f3cbe86236a3a03330a910d82e41fd335de9fc61646701654f6d9d861
+media.flag.afghanistan:
+  path: ug-flag-afghanistan.svg
+  sha256: 9dcd8bf5d83cd438a71a0688d523d0b2e59b52106248402202b2e67a5cd5d583
+media.flag.aland-islands:
+  path: ug-flag-aland_islands.svg
+  sha256: 1cc23fd5f29fe346e3470d10451e9e2eafdd5fbe7431c211d65dbe067262d9e5
+media.flag.albania:
+  path: ug-flag-albania.svg
+  sha256: 1ee6821cd1531890a66cfc730425248473c4cb1dc69158d5182fee8617886d57
+media.flag.algeria:
+  path: ug-flag-algeria.svg
+  sha256: 2db9427b208a3b0114810c16d1daf6d42be5966da08adc12fd8362545c5a8838
+media.flag.andorra:
+  path: ug-flag-andorra.svg
+  sha256: 27cd7ccb6a6fd49d3de4e1a05134d483f6f720e15ef4bb888b54e2a0b2d0404f
+media.flag.angola:
+  path: ug-flag-angola.svg
+  sha256: ce158a961055eff088f7a77463ff7119ef3ca863e6d9c4fdea2dddb9fa373022
+media.flag.antigua-and-barbuda:
+  path: ug-flag-antigua_and_barbuda.svg
+  sha256: dafea46e7fe2c7f765eaa3deccf6a71ced25be7570f8e61fb90fe7c6b3fc6da6
+media.flag.argentina:
+  path: ug-flag-argentina.svg
+  sha256: 59a6ef7c199d2bfe36370e3e336006cf9165411e40c552437dd131ec57d4858d
+media.flag.armenia:
+  path: ug-flag-armenia.svg
+  sha256: 227bcb9aba75ef9245ee8648e3c1368349baf888789baa683386b2800399cfd2
+media.flag.aruba:
+  path: ug-flag-aruba.svg
+  sha256: 60df0c9be21948e2f5e13d058110bcef89d7795c3e1f753fbd21bd79db0051e9
+media.flag.australia:
+  path: ug-flag-australia.svg
+  sha256: 33591f25274f6639c699c33b3899d197ff7893bea4784d81a10e7511211255a6
+media.flag.austria:
+  path: ug-flag-austria.svg
+  sha256: fe72018904e750f97ac6dc618dd47b0a947a6a6c6a48d62ee818a723e1a05f84
+media.flag.azerbaijan:
+  path: ug-flag-azerbaijan.svg
+  sha256: a8f428eb254cfa9c9e3223aed00900efe2cd90680bfa79fe543308809e2cf750
+media.flag.bahrain:
+  path: ug-flag-bahrain.svg
+  sha256: fd8869a62e8a94608e15bedf02f6eeab7ac975fe834371bb2f3047db9fa285f4
+media.flag.bangladesh:
+  path: ug-flag-bangladesh.svg
+  sha256: 0915929762f3637e8f6f5d305e65a4274085732411428289889fe2df8b14b6d6
+media.flag.barbados:
+  path: ug-flag-barbados.svg
+  sha256: 58bf1710d05fb0218cb4824928851163fb8fee4cf2c56d29c636e5fe4a1cfdf2
+media.flag.belarus:
+  path: ug-flag-belarus.svg
+  sha256: 6e0120a57e480ee42b22c28c817f06b524ad26c8fc1bdac59cc4968cbe54a1d2
+media.flag.belgium:
+  path: ug-flag-belgium.svg
+  sha256: 6f18ddb951baa6d7de959603d550e64b61de913b27fc91e49da96d3679c63626
+media.flag.belize:
+  path: ug-flag-belize.svg
+  sha256: 9f13d2e289c43284260c9d6a6de3326b54b50e09433c5559ac287dfa6a1c27b6
+media.flag.benin:
+  path: ug-flag-benin.svg
+  sha256: 4b0b9a19730602f22444bdfe49106e60bc1dedd19e4da129674037b0c13a0984
+media.flag.bhutan:
+  path: ug-flag-bhutan.svg
+  sha256: 86214aa8f2c24be1e7d0a729853b1ca7faa3d22699939331a551c761d7402d4a
+media.flag.bolivia:
+  path: ug-flag-bolivia.svg
+  sha256: 3010bf58668ac58ae5a1b614867cf94c53b229f2d26679c0ca04cae6d936ced1
+media.flag.bolivia.blur:
+  path: ug-flag-bolivia-blur.svg
+  sha256: f13669cab4afb991b9851a9c55bb94be5a2c91303a6f8bbb4407a9ffd67951c7
+media.flag.bosnia-and-herzegovina:
+  path: ug-flag-bosnia_and_herzegovina.svg
+  sha256: caaa68769476c73832ab35a0d9dd56a084d672661df2e8b6a855cb615e21ccf8
+media.flag.botswana:
+  path: ug-flag-botswana.svg
+  sha256: af7e006813fd81daedf5538e6fa22971fb7ae7d02e0d7bb9763d2a11dc32f92e
+media.flag.brazil:
+  path: ug-flag-brazil.svg
+  sha256: eda74fa6eb81017b677367889ab0b4d24b22b60aac2a35ce5dbc1792b24cbb90
+media.flag.brunei:
+  path: ug-flag-brunei.svg
+  sha256: c3a9553f05b676695db9dc1c50af43144ec89829b1fd583b7bd4173646f32051
+media.flag.bulgaria:
+  path: ug-flag-bulgaria.svg
+  sha256: 2a105bafe300c821f50105eab94754cf17a64019aa34ebb6533fdc8800bd5df0
+media.flag.burkina-faso:
+  path: ug-flag-burkina_faso.svg
+  sha256: ff92bfc54b2744f22903e1bd96d5c244e908dc6218508e6dbb99b47d1553c104
+media.flag.burundi:
+  path: ug-flag-burundi.svg
+  sha256: a27e731dfe672e40d9dcadbd2439af39f017e28898d5d362dd80d87db6fc4437
+media.flag.cambodia:
+  path: ug-flag-cambodia.svg
+  sha256: b0455e098942d6480e2c4e4425e6cb9cbc4a4dd5506e2e112317e03abd0e19ca
+media.flag.cameroon:
+  path: ug-flag-cameroon.svg
+  sha256: 31f27f66d921bb39c62794ca7c693917f1699bd9821230e3bb696a4c9192213f
+media.flag.canada:
+  path: ug-flag-canada.svg
+  sha256: b45f7b790a4cb00cf7d70840788d89fcd94b99996600912fb3d51d29a8449193
+media.flag.cape-verde:
+  path: ug-flag-cape_verde.svg
+  sha256: e5804ebded51a062f70824a30706bc67129bc81c277c4287b6c53aa3e3bb0875
+media.flag.central-african-republic:
+  path: ug-flag-central_african_republic.svg
+  sha256: c37f06783b6c13786b89142a19b6d5a7902d8e171544b16c6284ddb66d735e55
+media.flag.chad:
+  path: ug-flag-chad.svg
+  sha256: 0f9d2927b9181164d8ebcaf0d09e17e012e2bb29ad6e6b9ee31819471c1cb92e
+media.flag.chile:
+  path: ug-flag-chile.svg
+  sha256: 555aa3b2fa5b5b7055ad695a278c9a69c86c15ea3854f7bc2e7670c78e4a0eb8
+media.flag.china:
+  path: ug-flag-china.svg
+  sha256: fb19f0cbbd845823ed21dacb23130d0dd2d107bf6bce23326887288dfc21ea99
+media.flag.colombia:
+  path: ug-flag-colombia.svg
+  sha256: 5b1ac059f1dd83e206d0952b5f58db7fd48e852c73e6acd4e44258fb3dc34424
+media.flag.comoros:
+  path: ug-flag-comoros.svg
+  sha256: d589cf1e15024565d4e687814c45d8d5fd8aaa9c05e39f85845a5c1156ea3b4c
+media.flag.cook-islands:
+  path: ug-flag-cook_islands.svg
+  sha256: 6d95be103fed84b9eefb0e11321d7bc6310175101f66cb88e623b783ffbbcdad
+media.flag.costa-rica:
+  path: ug-flag-costa_rica.svg
+  sha256: 12500f9b992b7f73753ecfab9ce937c7a2ef1c9cbc13978f032703ff7b82792d
+media.flag.costa-rica.blur:
+  path: ug-flag-costa_rica-blur.svg
+  sha256: 3d1f0215940cbf23037835693efd99fc8ceaf1274b7b94beefc7cdcd4830d681
+media.flag.croatia:
+  path: ug-flag-croatia.svg
+  sha256: 3b63eeef847d244485a0e288c631c9cfbc1292508dc3cfb2527e6d48611cf972
+media.flag.cuba:
+  path: ug-flag-cuba.svg
+  sha256: 0d778924aa7a8730fcec5d11d2992d8232200136d4827f6db401c5571d349efc
+media.flag.curacao:
+  path: ug-flag-curacao.svg
+  sha256: bafa0d168b32aff0338094aeefe8932632d838635e1f28c3a5bf747201cb1d4c
+media.flag.cyprus:
+  path: ug-flag-cyprus.svg
+  sha256: d2f33f36cd0d153388b59e97b02595d2ec5bddb7c47a709f9d78308fd385c610
+media.flag.czech-republic:
+  path: ug-flag-czech_republic.svg
+  sha256: f4b01ecf8bc6de4b9b2fcf7c3324d088957a61dc431f24d83eecfeb238e123de
+media.flag.democratic-republic-of-the-congo:
+  path: ug-flag-democratic_republic_of_the_congo.svg
+  sha256: a4977dd93214d1e7ded01d525597a61e78090821dd6121cfbb6ff721a07dbdda
+media.flag.denmark:
+  path: ug-flag-denmark.svg
+  sha256: 9067fd51c1cbf71d0027c2a0d45fefc1bd9186fb8446585ba6995024a2271289
+media.flag.djibouti:
+  path: ug-flag-djibouti.svg
+  sha256: 99316e99def2b98302ebca8dbec91ed8f538e525895af60d921077ea3c9ee498
+media.flag.dominica:
+  path: ug-flag-dominica.svg
+  sha256: 90275efaa369c93c79ec730b16b0fc264d69e309996a0da216d64a642c014511
+media.flag.dominican-republic:
+  path: ug-flag-dominican_republic.svg
+  sha256: c7cf770a23e2fe1d6e77a9988b44082bd0618217f29bfc05529660a1364f0ebd
+media.flag.ecuador:
+  path: ug-flag-ecuador.svg
+  sha256: 476040ee571dbfcb0677d9d1b37e763ce6f06dcc82398c3acdd7304629bfbe08
+media.flag.egypt:
+  path: ug-flag-egypt.svg
+  sha256: df23546b077e4984db20186619cd35511b6123b14648789c6f4ce20ca8d5a91e
+media.flag.el-salvador:
+  path: ug-flag-el_salvador.svg
+  sha256: 209c5698f8fad2d37e253b38caed27d8076a85f7a16608edf906cc95f8b5ea96
+media.flag.el-salvador.blur:
+  path: ug-flag-el_salvador-blur.svg
+  sha256: 66cf0537f68e5b9bede807e173cff5f426ebb6e42cab63dec2e95c7755b9190c
+media.flag.england:
+  path: ug-flag-england.svg
+  sha256: 4e5aaae6ded7058a9c835248f181adf45b935cb1563b1abda6329f6aedea07a2
+media.flag.equatorial-guinea:
+  path: ug-flag-equatorial_guinea.svg
+  sha256: dc580edd216cc847a34f759e20ac4af4b2199abf47bfc25b49ad36c8b1bd48af
+media.flag.eritrea:
+  path: ug-flag-eritrea.svg
+  sha256: 6a646c8c87e677462e9267b2687e4dcaf0e60bd12b00705bd3191bacc06ca876
+media.flag.estonia:
+  path: ug-flag-estonia.svg
+  sha256: f8f478a07bdc817368fd80d95327191c8bfd115d8d71d1bbbfeb27c6bf00d7ea
+media.flag.eswatini:
+  path: ug-flag-eswatini.svg
+  sha256: 778ea187e2e0772b0afccd12595a5e4721cbc317bd8318df93a38678a8d35fa7
+media.flag.ethiopia:
+  path: ug-flag-ethiopia.svg
+  sha256: 2df01c36530ecbce301f25b97aa8ad0fd2f696433c8520a8ea0bb71bb331381c
+media.flag.european-union:
+  path: ug-flag-european_union.svg
+  sha256: f5866a7fb5b805b47e0984ff4a61f012cc3acb589376051b851ac36b9afd58c3
+media.flag.faroe-islands:
+  path: ug-flag-faroe_islands.svg
+  sha256: a4476b9a5a508cd295fe69a5470be272e924c7a11beec034be066a14f2e48d44
+media.flag.federated-states-of-micronesia:
+  path: ug-flag-federated_states_of_micronesia.svg
+  sha256: af7d633ad6d6e1ea7f0f4ec4621e9d2bd9f43f3c854e559058fd7604f99d8acb
+media.flag.fiji:
+  path: ug-flag-fiji.svg
+  sha256: 1210a0a358830fd13956f4256f2784a6217f88b327518eaf46293dfa5e420130
+media.flag.finland:
+  path: ug-flag-finland.svg
+  sha256: 45ffed1fa8b8a82492bad765e4ab3275cd19cd5fa865f03c8fd808155d5b4921
+media.flag.france:
+  path: ug-flag-france.svg
+  sha256: 15e906d2735b1f24e413563f5b473360058eb677e5f12362bf781418ab9aac00
+media.flag.french-polynesia:
+  path: ug-flag-french_polynesia.svg
+  sha256: 71a67872bb79de4f2d5fa5d91f8e2ca64faf5dfe891ab4a2c5b2a4302fb08b2c
+media.flag.gabon:
+  path: ug-flag-gabon.svg
+  sha256: 12100dc5da39f3094c42b0e18966a437ce97d08f040d660113509a53d12d2ba8
+media.flag.georgia:
+  path: ug-flag-georgia.svg
+  sha256: 7bbf283854e99364b1d038ab1ee1ff67e37bfa50dc53edd048002208831cb591
+media.flag.germany:
+  path: ug-flag-germany.svg
+  sha256: b22b364afc7ba7b9c060783851c0d745e17faa351714f11daf996a1039ae73b9
+media.flag.ghana:
+  path: ug-flag-ghana.svg
+  sha256: 570d8150d0d39013b52c807e2c1246f235f319af25e34ec4bd49d19b9f50e5df
+media.flag.greece:
+  path: ug-flag-greece.svg
+  sha256: 66a02b76302c2f19eefa23bf14c92fe25e9d7e347a0a697266327c235b1dfcf1
+media.flag.greenland:
+  path: ug-flag-greenland.svg
+  sha256: 4c1771c4256f35fe9dbdd114c6e943fb55f12fa598c5ad40026789b2ac67bdbb
+media.flag.grenada:
+  path: ug-flag-grenada.svg
+  sha256: 0d9b3abd52951929f5fa71e48d40c6898bf04952a922230ac065e71f5a3b87cd
+media.flag.guam:
+  path: ug-flag-guam.svg
+  sha256: 9ebcfcbfb00f27b8e693afe5108a6ebefc1d7c992473599cd4412ea20ee82954
+media.flag.guam.blur:
+  path: ug-flag-guam-blur.svg
+  sha256: f902dd625ded2e4ea63a70cfc8f6bea72daa118d854bc25cbc42c0a33dd01a43
+media.flag.guatemala:
+  path: ug-flag-guatemala.svg
+  sha256: 1904d1f53cb92d110f3fe700a05a0e13cba1d9bb36ccb32cbdce53daefa5fe34
+media.flag.guinea:
+  path: ug-flag-guinea.svg
+  sha256: 55c6c086b18c0e799f4a7b06ec1ec9e5f65c6a7a67715480a1afc7cd35b3f560
+media.flag.guinea-bissau:
+  path: ug-flag-guinea-bissau.svg
+  sha256: 47f170088eb7de57babd97cd66df293c8b88da240a4a936d2848595a99d4dfc4
+media.flag.guyana:
+  path: ug-flag-guyana.svg
+  sha256: 4b193b4af2477e69a922de0599285eb111aa834b8d97e103e398646a3ffd16a2
+media.flag.haiti:
+  path: ug-flag-haiti.svg
+  sha256: 79f0a760f1c2008fbe9a3ba8cc0781ee8234c0b39a734441b5c98b5dd195e43e
+media.flag.honduras:
+  path: ug-flag-honduras.svg
+  sha256: 2646dc8c4294f39129c83c163a350ee1ee6a43e36d2f5f35d4f8e99147215984
+media.flag.hong-kong:
+  path: ug-flag-hong_kong.svg
+  sha256: 5c11f14d5092580d7bc8ce063cb5cb758f2f48d22758c1f81b016b657b310daa
+media.flag.hungary:
+  path: ug-flag-hungary.svg
+  sha256: cfc85970e73215ed636fbdc8a79e6a67c83840d03df7b360363e9080b453b9b3
+media.flag.iceland:
+  path: ug-flag-iceland.svg
+  sha256: f98d2724a29ce04834d27bd4acb7e5be3ebee549cb89c638fed01cb2c623f36a
+media.flag.india:
+  path: ug-flag-india.svg
+  sha256: aaa168ac9eb3e5fcbe3799fc72959a69b45195f23f38edd6e8432889c741dacf
+media.flag.indonesia:
+  path: ug-flag-indonesia.svg
+  sha256: 4f6a5e8faaa819106c5325ead63c25c761b8d05c26c77fc01d84fc0384716fad
+media.flag.iran:
+  path: ug-flag-iran.svg
+  sha256: c81e770bb9a0cbef7d5a64a3ce9de34501394c9b39d91c7dc9d58796d31b5d97
+media.flag.iraq:
+  path: ug-flag-iraq.svg
+  sha256: b8d922ee59f18b7a58fcf60b36da6dc592e15595fc20c21129447f53289b2509
+media.flag.ireland:
+  path: ug-flag-ireland.svg
+  sha256: 80fb7b163f2d6c220f4162dfc7e067e5219f2f07d9e61e4544536b0b7e61cb23
+media.flag.israel:
+  path: ug-flag-israel.svg
+  sha256: b7d8389b34c99e4d23c6ca64e50310482927c8e3e930c41f1c0907cc4a834c46
+media.flag.italy:
+  path: ug-flag-italy.svg
+  sha256: f2769de5d7b3ed39a36f1986fd52aba82a575186379722675ffe58a5e173f73e
+media.flag.ivory-coast:
+  path: ug-flag-ivory_coast.svg
+  sha256: 758032ac111fe802537ff06acd3beca6301af85b07ba928655b02c9fd9c010ca
+media.flag.jamaica:
+  path: ug-flag-jamaica.svg
+  sha256: 9525f5291e689e3dedd4f99db0536e6b898bfb8c4c055b5c72a06fc7395bf0d2
+media.flag.japan:
+  path: ug-flag-japan.svg
+  sha256: 9bbcb889e3e4402ed669b6ec136ab624b15d11f1f6ff1f413c215c5f0da217f0
+media.flag.jordan:
+  path: ug-flag-jordan.svg
+  sha256: 759acbbd308ecbcc5661f33fc954e64671f136af105aff8a8fd1929bdabb5ab8
+media.flag.kazakhstan:
+  path: ug-flag-kazakhstan.svg
+  sha256: 8cb157fe52cf2f0300b9f692e44ac876a3a4f4aff70d37404d98ecdc886cf04f
+media.flag.kenya:
+  path: ug-flag-kenya.svg
+  sha256: 07c04a2d2a94fb34d1f3b17b3d12347c006e7cc1d095cfc6f202547a5abb521a
+media.flag.kiribati:
+  path: ug-flag-kiribati.svg
+  sha256: b0c1d56abeefbdacbb85d1d05d23f6dd8e8c2b20d829a9725618c55483c39be4
+media.flag.kosovo:
+  path: ug-flag-kosovo.svg
+  sha256: 3638068f2ded8f432cf7e124b26fc22957dab0cc5a890181d0a514dbc104c431
+media.flag.kuwait:
+  path: ug-flag-kuwait.svg
+  sha256: a64acbd555fc7a11b83733200e7607e43312cbff9045bada3c85c030ca170fc2
+media.flag.kyrgyzstan:
+  path: ug-flag-kyrgyzstan.svg
+  sha256: 35b3f6ac3ba6addb5b666be977b58f183fd3b925997fa370a405f5577906a3bb
+media.flag.laos:
+  path: ug-flag-laos.svg
+  sha256: 71859aea2e4306c3f1faf1cea30308906c52344baea416135584e282dc35d588
+media.flag.latvia:
+  path: ug-flag-latvia.svg
+  sha256: ffefc0e1ca9166fbd342a92e5280200a250821a72d99c29876fb89ec1795f445
+media.flag.lebanon:
+  path: ug-flag-lebanon.svg
+  sha256: 53be72b0c66043db8bc6674af7e64b9871a2589802c6b1c1af7b3208cd314637
+media.flag.lesotho:
+  path: ug-flag-lesotho.svg
+  sha256: 30fc2366efbe845491c6762f2c446d5bc8660e722cf8403e819693daae9fff50
+media.flag.liberia:
+  path: ug-flag-liberia.svg
+  sha256: 6467625949525839411c0f1def7228781b9efacfd365897019399f53e877695e
+media.flag.libya:
+  path: ug-flag-libya.svg
+  sha256: c0319dd6d6fd1d1689717bc802d75880cffbcc12795ec9d91607d48732b8f9fa
+media.flag.liechtenstein:
+  path: ug-flag-liechtenstein.svg
+  sha256: da1213e4d47aca0ed2446224dcfe9f038d7bcd3556b08a7f967515953b137c7c
+media.flag.lithuania:
+  path: ug-flag-lithuania.svg
+  sha256: 5c0c73b8e24844a22eb75872f0f7b25f6a2cba164e70fe57a1bb2e23bea61878
+media.flag.luxembourg:
+  path: ug-flag-luxembourg.svg
+  sha256: 6e9199bad9968b9db15b5e782f2fcf337650a0e7597a82e49722b8009d2dd911
+media.flag.macau:
+  path: ug-flag-macau.svg
+  sha256: 133adfe3784224be07e016529d64230e6bf98a5041709407634b4a3587025ac9
+media.flag.madagascar:
+  path: ug-flag-madagascar.svg
+  sha256: 91963b805bf0fe1d641a2c0a0b42be3debc2d7010fabbc71ac3c6a6e3eb74bbd
+media.flag.malawi:
+  path: ug-flag-malawi.svg
+  sha256: 600860f27bb19031799d0fcf5e4ab47bc73f2d27769c2f1b305898d6412f9296
+media.flag.malaysia:
+  path: ug-flag-malaysia.svg
+  sha256: 69250b298d6f27540fe2e74551704078df41164947ae4e2ba8d68d6aeff05766
+media.flag.maldives:
+  path: ug-flag-maldives.svg
+  sha256: ff2a309d46e11c0a888cfb850e935ae9f0158c17aff27ff6c319a8119f494879
+media.flag.mali:
+  path: ug-flag-mali.svg
+  sha256: 219f5a684296dd3ff28a3b1eb4daffdd0214e18ecc4224bf333316334db60ac4
+media.flag.malta:
+  path: ug-flag-malta.svg
+  sha256: 70407d099319d4c6f71fb64a3b7afe58a062b74cb5f1550808269321e95ea7da
+media.flag.marshall-islands:
+  path: ug-flag-marshall_islands.svg
+  sha256: c93b8254f891a15f93c855c9ab4959ea4a8be3583efeef4d96ca553c27f271b6
+media.flag.mauritania:
+  path: ug-flag-mauritania.svg
+  sha256: 8ad1f2a554c571ca1e7b3dedc1985f786a9b7cc296cc3ad344c9b1b4cac76643
+media.flag.mauritius:
+  path: ug-flag-mauritius.svg
+  sha256: d5bbec53c5a325cfe9496e61fe00df9fc386eb1b07ad6ece87f46cc18e86f5bd
+media.flag.mexico:
+  path: ug-flag-mexico.svg
+  sha256: c0dbeaec49ddf559e47c07d1da6cff744597462dd6b7cdb4fa982231deea5a94
+media.flag.moldova:
+  path: ug-flag-moldova.svg
+  sha256: 7428616f7b5ef12a39d63209ab6091ee95b28e3a502d0ab003ae5f9480a54c02
+media.flag.monaco:
+  path: ug-flag-monaco.svg
+  sha256: aac34f852b55522f1952bc519118efb84f521f0b33b1cd7bcffea92812ee9bb4
+media.flag.mongolia:
+  path: ug-flag-mongolia.svg
+  sha256: 02a40485ec94028cb49c2bced97eb6c76852ac5474c5361ffaa7c3cc09191eca
+media.flag.montenegro:
+  path: ug-flag-montenegro.svg
+  sha256: 81437ec736ec80d1fddac2c4040a8f9e8613b7f958a588619f7e0338096d0901
+media.flag.morocco:
+  path: ug-flag-morocco.svg
+  sha256: 79eafabe2906bf6118a978eabf029d73f01b280f8df807900ff6f3cbff76ba47
+media.flag.mozambique:
+  path: ug-flag-mozambique.svg
+  sha256: df1b80efa0960b446a07387c5454d9bb6642fb40e8f3c76eb24251f583775997
+media.flag.myanmar:
+  path: ug-flag-myanmar.svg
+  sha256: e1fe8ae752ce3e481bc3350429f9cba773a94192b6c08f256791e50aac1104ff
+media.flag.namibia:
+  path: ug-flag-namibia.svg
+  sha256: a4a019024e5fde797eebee5425fb948cd1269be4edfa5f75c0c93eb7d91f5c93
+media.flag.nauru:
+  path: ug-flag-nauru.svg
+  sha256: 4b9ef7370a3cc25e00128bd73f9f336199a2026446f5da01dacaa6877906b2e5
+media.flag.nepal-nobox:
+  path: ug-flag-nepal-nobox.svg
+  sha256: 0759739ab047f4aaef3288d008683b1335e3de74a7e0868d819697e24ad9f0ba
+media.flag.netherlands:
+  path: ug-flag-netherlands.svg
+  sha256: 0383ea5a55310ee609202f4a68789ce97c37d9d69991e3e5195d6ef75c9e5308
+media.flag.new-caledonia:
+  path: ug-flag-new_caledonia.svg
+  sha256: 1b0c993fb43f6dfda4beb64e93e568b951ccbd83b95ed53d11f182cd1d165d4f
+media.flag.new-zealand:
+  path: ug-flag-new_zealand.svg
+  sha256: 9427ba03cde92269fd6fbff820a7766a48f4d5616ea9b8d859757349ef83f577
+media.flag.nicaragua:
+  path: ug-flag-nicaragua.svg
+  sha256: 877b3632ffc6b99bfd7f0c55945ee99098bfeb9320abe55c6aac878dcf902769
+media.flag.nicaragua.blur:
+  path: ug-flag-nicaragua-blur.svg
+  sha256: 695a0e0a99d4664aa9de286ac6a8e44754b94184ef988a960f132129b10ff0eb
+media.flag.niger:
+  path: ug-flag-niger.svg
+  sha256: f8cf138a3372015569fc71165816be2469797a66d4825dcc0a470ead941cbebb
+media.flag.nigeria:
+  path: ug-flag-nigeria.svg
+  sha256: d7367c7f3527444f343e8e9954db3821a817dbdc352e428d0bd1b723e46a1fec
+media.flag.niue:
+  path: ug-flag-niue.svg
+  sha256: 6163682e9563b8fa3119e34faf437e47ed446d03fbc90dfa05fc80fbe42c5d51
+media.flag.north-korea:
+  path: ug-flag-north_korea.svg
+  sha256: 23c09c7b1509de8d6db8785c61a4f06f19242f704a9cab4a6c4e2c9c241c1cc1
+media.flag.north-macedonia:
+  path: ug-flag-north_macedonia.svg
+  sha256: f8ef1e1cafe42d14d88231edbb6bad55089c00ffbc3ab4043f580344e9c3f5bf
+media.flag.northern-cyprus:
+  path: ug-flag-northern_cyprus.svg
+  sha256: f37e5c1026f68e60ce863856c6066dbb3456e1c2b97c982d3806323c2d562f48
+media.flag.norway:
+  path: ug-flag-norway.svg
+  sha256: e26ed18877e24818bdf8cc0085ec00157161e2f869e5a2273035ae6297d5094d
+media.flag.oman:
+  path: ug-flag-oman.svg
+  sha256: 6df54931f8f60f2c91b983137d835ae2a574fc0fe686cc7010ada1aa05d69bca
+media.flag.pakistan:
+  path: ug-flag-pakistan.svg
+  sha256: 6b84d8209290e44e675c84cf794469f7804f5640305bcf22da1fc835dc03c127
+media.flag.palau:
+  path: ug-flag-palau.svg
+  sha256: cde6aa5fd3e2ec5f04163a17c03c968eee69dd9bad9d2259481e7ff92f162ac4
+media.flag.palestine:
+  path: ug-flag-palestine.svg
+  sha256: af17c1bf4c54dfe6c26e789823641acddfe55e6c43ef39eb507a8279bac6cf0d
+media.flag.panama:
+  path: ug-flag-panama.svg
+  sha256: b84eb984b00c3133c71fce84d4a45f64e764ce69d203bee8598a19fc91faa76f
+media.flag.papua-new-guinea:
+  path: ug-flag-papua_new_guinea.svg
+  sha256: 10cd2ac0f08a255038f7b0853d0209e648eb7069ecc006a54d92766fce967ea1
+media.flag.paraguay:
+  path: ug-flag-paraguay.svg
+  sha256: 0e5f95695c752eb60cedd42c9c3b9c9c084c3f8c4440f64f9f0a2f65c50699ea
+media.flag.paraguay.blur:
+  path: ug-flag-paraguay-blur.svg
+  sha256: ad128dba2f44716134b8bb686ca77112f9186070e57dd3287e9d78d431fd4863
+media.flag.peru:
+  path: ug-flag-peru.svg
+  sha256: c62921ba81a1e0ccb31fdd6128327f78a44dc45cbf6cd34bfcbf6fb8d6d8fd92
+media.flag.philippines:
+  path: ug-flag-philippines.svg
+  sha256: cffd7eebbc18e7cd7232c79cd5b34fd66b715b177f33d5aa0ea8c9346011963b
+media.flag.poland:
+  path: ug-flag-poland.svg
+  sha256: 99f395d673ce9848bfdecfceed0afce0c07ac34c52d983972cd4de285876c339
+media.flag.portugal:
+  path: ug-flag-portugal.svg
+  sha256: 1eb59d079702df898c558fb4018820227fc3d6f93ba52e1c40e86496dfa03f49
+media.flag.puerto-rico:
+  path: ug-flag-puerto_rico.svg
+  sha256: 50192480665ecaf40c1b844cd2ec8bcc642aff3a1a048a590d48612c98de3b86
+media.flag.qatar:
+  path: ug-flag-qatar.svg
+  sha256: a200e82fa97923e93f58940bdbe9236561b3b581ca198ab2c6948ed386b902a2
+media.flag.republic-of-the-congo:
+  path: ug-flag-republic_of_the_congo.svg
+  sha256: 2e64915649a815bc7cd36e38b5cab5a5ff2cfbf346d92d0c745e855588eb7fa9
+media.flag.romania:
+  path: ug-flag-romania.svg
+  sha256: b9f801edf1a4c5b0dbb873a8a5f1ae77970cae16d826f7b1b58605e2742750d3
+media.flag.russia:
+  path: ug-flag-russia.svg
+  sha256: 39662dbf0161304e3843054eaa5b20906ba938790fe1f59ca328cbf24455badc
+media.flag.rwanda:
+  path: ug-flag-rwanda.svg
+  sha256: a8cb59bcabc2fe913bde5bcb60bbf46f199aaff7f7427ae5eba7326d8950ddbf
+media.flag.sahrawi-arab-democratic-republic:
+  path: ug-flag-sahrawi_arab_democratic_republic.svg
+  sha256: f126eba1610ebeeefdc4c188f26cd852efb6253a1a9a92737f57f7ff2733cec8
+media.flag.saint-kitts-and-nevis:
+  path: ug-flag-saint_kitts_and_nevis.svg
+  sha256: ceef7a09d8fc28817ca7acb372dec47fa041712b61f11aa647d53cc6dcf94c00
+media.flag.saint-lucia:
+  path: ug-flag-saint_lucia.svg
+  sha256: 657a82299431ec0a18d06f398e4f7c1f8925c7ed67431412104c6b029b01fd5e
+media.flag.saint-vincent-and-the-grenadines:
+  path: ug-flag-saint_vincent_and_the_grenadines.svg
+  sha256: c9bea3b01bdef7e83eb9425bc8965f82309e246108fb7ad26f2289cbca72d72f
+media.flag.samoa:
+  path: ug-flag-samoa.svg
+  sha256: 0584aa33c92c20c192dd682f2189fccead7f908bc3befdb725e3b191d3a9bfc2
+media.flag.san-marino:
+  path: ug-flag-san_marino.svg
+  sha256: b296fc21543c0fd399690e26b20e6f885eae99f8e3d1d764a6c9ead3f6fd2816
+media.flag.sao-tome-and-principe:
+  path: ug-flag-sao_tome_and_principe.svg
+  sha256: 374dfeb4390f668e99b8bc5c2f9078a513914a284d04e4886077a3d2c5872bd0
+media.flag.saudi-arabia:
+  path: ug-flag-saudi_arabia.svg
+  sha256: 970f4cdd215e48f56e50da942717206a92050abdc49943e50597e0bb2e394f89
+media.flag.scotland:
+  path: ug-flag-scotland.svg
+  sha256: 3819a44cbc87275b4c095b8e27baafba95baea4a4e041e98709a59faa0f1521d
+media.flag.senegal:
+  path: ug-flag-senegal.svg
+  sha256: fe1a10d042fa4020f35fd55882a46a252e1df499a24551822011f5859b1fd434
+media.flag.serbia:
+  path: ug-flag-serbia.svg
+  sha256: 7e374518c8ee39be64389f129126e03b5ab130bb150dd45a1e06b2be16d694f7
+media.flag.seychelles:
+  path: ug-flag-seychelles.svg
+  sha256: 6e73a38248ee8ee14beeb2a36e7149d94af16f8fa42620d5fa8e8269f89375cb
+media.flag.sierra-leone:
+  path: ug-flag-sierra_leone.svg
+  sha256: 054b87e180187b88bb87005aeabe35d6ebb5fb03a2523160934eb01b5dbe4c94
+media.flag.singapore:
+  path: ug-flag-singapore.svg
+  sha256: 963b3da83bfac4aea29419cc6200c5d22993df8f6fb1fd435cb00775b35d85ae
+media.flag.slovakia:
+  path: ug-flag-slovakia.svg
+  sha256: 9a50505c80d43fed997c49b0cd8d1857d7e6366ec26504cc09c0347eb7b7e9c9
+media.flag.slovenia:
+  path: ug-flag-slovenia.svg
+  sha256: b4379f83746da9e6bfc84bbba1fdaf3c3bc8bbe15e6fac156e9f5d415f1525d2
+media.flag.solomon-islands:
+  path: ug-flag-solomon_islands.svg
+  sha256: 5c3e5b855bf2a8fa687147b56f782118a4953922f6689715021285d1b36584fa
+media.flag.somalia:
+  path: ug-flag-somalia.svg
+  sha256: 8e5f568178f51d43d39e63374a03fdc34bddca57c044f60ceb8b97379de8d63d
+media.flag.somaliland:
+  path: ug-flag-somaliland.svg
+  sha256: 431ae87c238127eb6140edc878b927abc1993f5846f61db8a3f6497f2dd0381b
+media.flag.south-africa:
+  path: ug-flag-south_africa.svg
+  sha256: 93685d8de4d72eb4f86e8b70b358dddcef49b7ae9d54145eb5c04fb765bf70d5
+media.flag.south-korea:
+  path: ug-flag-south_korea.svg
+  sha256: 596cadd9d3309621a91db2e5e7c744b3bbb6f41164ff5d250fd3f27368202efa
+media.flag.south-ossetia:
+  path: ug-flag-south_ossetia.svg
+  sha256: c2c9d41c0a34787f189866a9e8df3ce6ccfe804d98240902178ec81a4e327184
+media.flag.south-sudan:
+  path: ug-flag-south_sudan.svg
+  sha256: 116024ad7043f8543199dd2e4026ad15c545f86c3e84a80edfa8ded39aae3d24
+media.flag.spain:
+  path: ug-flag-spain.svg
+  sha256: 5e9e71c908d8f542864ee81217c510cff5f8c2f92767046f6d0cb99cc6348e69
+media.flag.sri-lanka:
+  path: ug-flag-sri_lanka.svg
+  sha256: d3674d881bf3ce11ee74147cc67c10c98d54cefb33ca60b21c7c762cfe0239d2
+media.flag.sudan:
+  path: ug-flag-sudan.svg
+  sha256: 408b0173a3d0420e7001818e681ee0c39f5342a6db60634ad4bcb9e8c632d29c
+media.flag.suriname:
+  path: ug-flag-suriname.svg
+  sha256: f66ae740c352482b3e4e708a99127192c9df73026fe37f071126c0810c283e8d
+media.flag.sweden:
+  path: ug-flag-sweden.svg
+  sha256: 122d41ec82efbf0935f2c6f984f1d38ec03ea6ead1471987dac9d511c2c8fe4c
+media.flag.switzerland:
+  path: ug-flag-switzerland.svg
+  sha256: c13040ad92abe926239a6c111751f1e20ec1c0db955340e33ed683b3c33f1766
+media.flag.syria:
+  path: ug-flag-syria.svg
+  sha256: 9fc196713886d413a1e1800c161b820ec041d5f3354779e58eae5cb6ac5dd81f
+media.flag.taiwan:
+  path: ug-flag-taiwan.svg
+  sha256: 6fed992ffdc5522537cff1f6a8a2ead185061b155247bdb593c21d4e9a4d4f44
+media.flag.tajikistan:
+  path: ug-flag-tajikistan.svg
+  sha256: 88ab02096b2fdea511b3002f928b3d04f3e986783e8959527663e21c2d7d2e72
+media.flag.tanzania:
+  path: ug-flag-tanzania.svg
+  sha256: 086e1d01b2c5c9970d3ce4e093d438cd08ebab8c2a0c572878ed74bd4aa7da0a
+media.flag.thailand:
+  path: ug-flag-thailand.svg
+  sha256: 0444a1c65bdbbd5d554d6a42bb66c1faa548ec8f816f6ca9e35795875e1739af
+media.flag.the-bahamas:
+  path: ug-flag-the_bahamas.svg
+  sha256: 9cdd4221310d5cd60ffae622fc7a0ac6cace2f4c877774ea61295a45e935e30c
+media.flag.the-gambia:
+  path: ug-flag-the_gambia.svg
+  sha256: 3bd823e69adf0f580662d170bf3e24fa49505bf859c67e71807e0ddbdd5c80c7
+media.flag.timor-leste:
+  path: ug-flag-timor-leste.svg
+  sha256: 31cc9cc92f10a220a04be22e4f0007e4956ce831167cd7bffcce347967a4dbd4
+media.flag.togo:
+  path: ug-flag-togo.svg
+  sha256: f9686776a689f1ef039e85e05b5d5327155e9eb184d4a62631e79ca49f499545
+media.flag.tonga:
+  path: ug-flag-tonga.svg
+  sha256: 54727d9d0c154097e73e686a845f0caa76f787d27f57fc9e1ee5f2de0ec2b2cc
+media.flag.transnistria:
+  path: ug-flag-transnistria.svg
+  sha256: 8f72aa9a279485f04fccb47a388aef5b42b9924a4f72d3dd26d7106071a05ccf
+media.flag.trinidad-and-tobago:
+  path: ug-flag-trinidad_and_tobago.svg
+  sha256: d14cce1dfb46a39301479bc546060c06ad02cb8da423295ba879e7c282909636
+media.flag.tunisia:
+  path: ug-flag-tunisia.svg
+  sha256: 549e26ad86193e17d513fb660e36f3c5470483824971571343498bd792acbb64
+media.flag.turkey:
+  path: ug-flag-turkey.svg
+  sha256: 9e0456c82c3a27fa2e23da16a887d851e84f0c8dde8c80d15491b6edf5b9df66
+media.flag.turkmenistan:
+  path: ug-flag-turkmenistan.svg
+  sha256: 23b64971ffde6430a1db4dd259571c13c434f208011191940bc1f438d3acf02b
+media.flag.tuvalu:
+  path: ug-flag-tuvalu.svg
+  sha256: 173b2aef1efcf2017bf123c5dbd4c546a116c5f3b18e728a54c4c148dc44073d
+media.flag.uganda:
+  path: ug-flag-uganda.svg
+  sha256: 08555129378be03335ec4765f9932a008e5d7bbd0ca258f336de3a466bb1a975
+media.flag.ukraine:
+  path: ug-flag-ukraine.svg
+  sha256: 693c07afb613bd7a2c5992b8e5994bdca3276603d056e41b5f3363bb0248c987
+media.flag.united-arab-emirates:
+  path: ug-flag-united_arab_emirates.svg
+  sha256: 53131c756064612c8c28b858258634107fe770ad5bbdb79b935656078e0c25e3
+media.flag.united-kingdom:
+  path: ug-flag-united_kingdom.svg
+  sha256: a0afa83c1457735c75206845141006bb97eb3302f73abaca48489f6627d7fe6f
+media.flag.united-states-of-america:
+  path: ug-flag-united_states_of_america.svg
+  sha256: 32953654b55ce5a80c5b0024764d0ff7c103ac152e269d4b304046a2399b0efa
+media.flag.united-states-virgin-islands:
+  path: ug-flag-united_states_virgin_islands.svg
+  sha256: a2c87d92874725c20346866ab4029bf3d6760a40dfbf160d42860c95d602fe5a
+media.flag.uruguay:
+  path: ug-flag-uruguay.svg
+  sha256: df0cfe76438512bfc027179f4ebcbc68f5f039c3c195aabb67d3a65a220feb3f
+media.flag.uzbekistan:
+  path: ug-flag-uzbekistan.svg
+  sha256: fb2541c6262656a2da99684ea02c68a6cdba9dcb0e1464e10f332c9012f08a23
+media.flag.vanuatu:
+  path: ug-flag-vanuatu.svg
+  sha256: e2722814a6c9631b2ffa144d6e13c7362dc195879ec9a27148f92c40bac159e0
+media.flag.vatican-city:
+  path: ug-flag-vatican_city.svg
+  sha256: eb034bb2b48748b9be53e7b893bb9ee4aa9610e6a4b1ecffa030af6500772a38
+media.flag.venezuela:
+  path: ug-flag-venezuela.svg
+  sha256: db39108da18292ad1420600ee62afd829545e352033236d2fc3e9bc3e01004c2
+media.flag.vietnam:
+  path: ug-flag-vietnam.svg
+  sha256: 5412b70a7322e9dc16605f1b193444086f1fc569e12e60f94131358adc5df5c5
+media.flag.wales:
+  path: ug-flag-wales.svg
+  sha256: 297d87c7d8dda3d59922281c64f669cc5adcff4ec2dcb326a59a6f575f88f8ed
+media.flag.yemen:
+  path: ug-flag-yemen.svg
+  sha256: 692f2033b9909dd0602164e2e26db8b47502d2e7ef93ce8c7037e32d85aa3f3b
+media.flag.zambia:
+  path: ug-flag-zambia.svg
+  sha256: b667b0f2055c5e8d2f0ac1ff7112008731ccaa3eb09659dceebf8712f3ee665d
+media.flag.zimbabwe:
+  path: ug-flag-zimbabwe.svg
+  sha256: b49ff2f9de07f39f7c38e9f1cba48e264114440aba1989652515bae22f735368
+media.map.abkhazia:
+  path: ug-map-abkhazia.png
+  sha256: c701787efbccab967a15469f4f2e2d3a19e7a7f00091e17cb8a1dc4a1e8b0c95
+media.map.adriatic-sea:
+  path: ug-map-adriatic_sea.png
+  sha256: 14f2ec762b8e7b770feed7fe378a7c792d96a5833a20cdf017311a46ee907068
+media.map.aegean-sea:
+  path: ug-map-aegean_sea.png
+  sha256: 6ced169361dcc44891d3b20d37b2da665caccec4ff98d9e6b6b81bbc4a2bc425
+media.map.afghanistan:
+  path: ug-map-afghanistan.png
+  sha256: 6b78d5cf4d6db3b08ff3cb73fe9ce651ec70c7f956d2ee35f506e0bbabf84e28
+media.map.africa-nobox:
+  path: ug-map-africa-nobox.png
+  sha256: c042316bc219f4808ebcd80ba7a868c4fb636d9ed48cc514c342a955fe203554
+media.map.akrotiri-and-dhekelia:
+  path: ug-map-akrotiri_and_dhekelia.png
+  sha256: a1933fb300adab6ad23a9be0165eafb3331ceb3a29fba4195a5dc73b59edd421
+media.map.aland-islands:
+  path: ug-map-aland_islands.png
+  sha256: 8ec629cba3b864153c35fa51a20cdce441c14b03547db705401559cb57b1681f
+media.map.alaska:
+  path: ug-map-alaska.png
+  sha256: 117567ef9b89561eec54b6d509c34514b49d715135bda12e81809c365cdbf0ee
+media.map.albania:
+  path: ug-map-albania.png
+  sha256: c746aab05d8fa8a6a7d63aa964db24202bfe7eaf85b81862bb24bc49468234de
+media.map.algeria:
+  path: ug-map-algeria.png
+  sha256: 05815396f4f7992c81219190bb6cd2d0a816e9fee2c0266bf4cdfee0d7f20a76
+media.map.american-samoa:
+  path: ug-map-american_samoa.png
+  sha256: b468c6fca1355b3e4c7d3ef204d868d1292ec58735e9b3a57b18afcf9a7626df
+media.map.andorra:
+  path: ug-map-andorra.png
+  sha256: 19d400782375282de7ad3d246997206eb6ecc8dcfe00e56bf23a9391b8a960dd
+media.map.angola:
+  path: ug-map-angola.png
+  sha256: 2b4e89b24dc8631304ca08b8ad08345e6d885acd07ba5280c60d504249b74515
+media.map.anguilla:
+  path: ug-map-anguilla.png
+  sha256: c9451ea635ddcb98d7ace05a4d2b2c1894708ca884b5201b74ed0cf622e39e52
+media.map.antarctica-nobox:
+  path: ug-map-antarctica-nobox.png
+  sha256: e44160df2f21c65da82269ad7504d172c89930a30d64609994424f6cda76f7e5
+media.map.antigua-and-barbuda:
+  path: ug-map-antigua_and_barbuda.png
+  sha256: 330da1ced5c87be5570403bb515b17022b547c0454a708266892c24289a5abd5
+media.map.arabian-sea:
+  path: ug-map-arabian_sea.png
+  sha256: d8e8c43386a71d2f7ccde04511851c17ae9bbcfc0f67eb978cd7eeb0efd07774
+media.map.aral-sea:
+  path: ug-map-aral_sea.png
+  sha256: 65af49d0906ff1569a2740d81f2df4cac44ed7400314a48a3c80bd05068028ed
+media.map.arctic-ocean-nobox:
+  path: ug-map-arctic_ocean-nobox.png
+  sha256: 6a923f1bfa400b6203a1f3232e03aac89c829af699b409df7ecaf6f76c48a921
+media.map.argentina:
+  path: ug-map-argentina.png
+  sha256: b36e7dbb008a6ee07fd6fda2d45d5ceed120f9a91461a655db5bcf87da48b9a1
+media.map.armenia:
+  path: ug-map-armenia.png
+  sha256: 1c3ec0f266aeac513c14668c0138680e59390f896cb227cfd9ab2f3a335c53eb
+media.map.aruba:
+  path: ug-map-aruba.png
+  sha256: 83a9a01a7a46df997b8d7966395fddcc58c185a728e55cdf79951ce25304044f
+media.map.asia-nobox:
+  path: ug-map-asia-nobox.png
+  sha256: 110c603d6061a5c3bd7df79a1ff8511a23a846fa39015bbda741f31c27f5d90b
+media.map.atlantic-ocean-nobox:
+  path: ug-map-atlantic_ocean-nobox.png
+  sha256: 8f48b73159779163f327870495846a8ade5bf920e0d2db9a2e60337ef5e9fd5d
+media.map.australia:
+  path: ug-map-australia.png
+  sha256: 0e93ec8ad254c850b9307a0173d3a139475d9b26a37a3acce2cd592af2532e23
+media.map.austria:
+  path: ug-map-austria.png
+  sha256: 65bc759142249d8e59085c62c642c5e6728bec59b501fdc2cb543625349e04a0
+media.map.azerbaijan:
+  path: ug-map-azerbaijan.png
+  sha256: 2a7fa1370aaca0492081327868e9ed206b8632fe7110f091ac94c93340d40ff2
+media.map.azores:
+  path: ug-map-azores.png
+  sha256: 482556bf50da88e5eef8f7e7574bc575f159ba552aab134b3d4f9b8535cab9ae
+media.map.bahrain:
+  path: ug-map-bahrain.png
+  sha256: fdcf45e417b31df44ff315866386776e33520461b87546a74c17e7e6931708d3
+media.map.bali:
+  path: ug-map-bali.png
+  sha256: a7bdebe1997f391066b20da7254d958e1506bee0606b363a7ad12bd13e47a6a0
+media.map.balkan-peninsula:
+  path: ug-map-balkan_peninsula.png
+  sha256: 038e6582d6d5ba9bf7e3cb938e9bf99ac5fdf2ff078136f58759930f55667b3d
+media.map.baltic-sea:
+  path: ug-map-baltic_sea.png
+  sha256: f6d75e55bca765a793bd6e0169f68b061aee46bc0f1070a47c94f91332c991e6
+media.map.banda-sea:
+  path: ug-map-banda_sea.png
+  sha256: 31be42e69e854d4e6888b237a10b452995fe3c7532450ff5c1e1bd3ea5009ef9
+media.map.bangladesh:
+  path: ug-map-bangladesh.png
+  sha256: ac7bb4c45d4e8277a96483332f305c8806f076fdf8d4ddfb8a5148c5729c4a69
+media.map.barbados:
+  path: ug-map-barbados.png
+  sha256: bff807e3f0c13aaeb6ef1e0f2493c898175211a8335882c4d3b0540991bbbd48
+media.map.barents-sea:
+  path: ug-map-barents_sea.png
+  sha256: cc754f1b076cf04bbd1a47c65c816637858082f4aed1591641ecc82ebbe02820
+media.map.bay-of-bengal:
+  path: ug-map-bay_of_bengal.png
+  sha256: 1e3b4a6beec1bbfea91150466f3c79ceb135830775da01b413633751736936c8
+media.map.bay-of-biscay:
+  path: ug-map-bay_of_biscay.png
+  sha256: 1a10a6db5b70ead16795dd93f154e98f03ec94fd813f253f3aff4a394aa8a6d9
+media.map.belarus:
+  path: ug-map-belarus.png
+  sha256: 61530fdb5360d313e138770ba7012487fd25287d35d70f60462319df76aeaa14
+media.map.belgium:
+  path: ug-map-belgium.png
+  sha256: 8f9fee6234a94662b623df48f65b86c20f18b27c276b4d7860efc86e264371bb
+media.map.belize:
+  path: ug-map-belize.png
+  sha256: cdef9a1ced1e1129f78d6d60c1a8063ebf4f8c6afd89ee6bb0c3d4d503b13234
+media.map.benin:
+  path: ug-map-benin.png
+  sha256: c6ebcdb3ed52afa3d9d1494660a98f55fb11ec0c0fae0056e5389bfd8256c885
+media.map.bering-strait:
+  path: ug-map-bering_strait.png
+  sha256: 6c3a0ba6d2f3bb8e7eced10eb12b87d4887e6c31bde31913d11f1423073003f4
+media.map.bermuda:
+  path: ug-map-bermuda.png
+  sha256: d67277c58bb1db26e0fefb6b43674dd4dd69613a64b730ff6264b6844e08d03c
+media.map.bhutan:
+  path: ug-map-bhutan.png
+  sha256: 7af840302913b8ebbab50cd9c4a437cf1042a4863bd44bfc89573810f201560b
+media.map.black-sea:
+  path: ug-map-black_sea.png
+  sha256: 73fba702d6644ccb2d46de64364e5cee7e81c072be351d855f1b1e5d520acef9
+media.map.bolivia:
+  path: ug-map-bolivia.png
+  sha256: d461a4cb0d4b845fdc61de1123efca9cc766aaea10dabd95202a1beb980fca7d
+media.map.bosnia-and-herzegovina:
+  path: ug-map-bosnia_and_herzegovina.png
+  sha256: 50646a6d975e468c0b50b5a4fc155670f6efbd1d1b917bd7de2306c247940e21
+media.map.botswana:
+  path: ug-map-botswana.png
+  sha256: 7084ec0c0424f979b6b81586222776f0ce4dcce7b0dd5a0c144b06f6d5c339fe
+media.map.bougainville:
+  path: ug-map-bougainville.png
+  sha256: 9e8255de4c3f2f68f87c19cf0750fd18b0631519663e89740a530f47736b483a
+media.map.brazil:
+  path: ug-map-brazil.png
+  sha256: a1382e49b32dd6eeb15e0c2dc5e7a357936c83811db15028c32159cc3f3732f1
+media.map.british-virgin-islands:
+  path: ug-map-british_virgin_islands.png
+  sha256: 112977a0eb8c5cc34700cfb3df220c28ee8fb7db6a3bfb8e6072d4d499b61c21
+media.map.brunei:
+  path: ug-map-brunei.png
+  sha256: 256908c378c72f751a8f3971b4b7a6d8b053f2b22fe2aa289bcb58a199c0245d
+media.map.bulgaria:
+  path: ug-map-bulgaria.png
+  sha256: ea29b9cff8d6f0e39eaaef68096641c083e8a53362d3d669ffe04a9fb6620190
+media.map.burkina-faso:
+  path: ug-map-burkina_faso.png
+  sha256: 8e373633dcf1d989e2f7ca7ff8844690840f7a69890500d2903612cba3baa2b3
+media.map.burundi:
+  path: ug-map-burundi.png
+  sha256: 033d7cffb267a9ca3631dc54f4082f85aa92a0d01f89733e750e1b5ae9930df4
+media.map.cambodia:
+  path: ug-map-cambodia.png
+  sha256: 6f39482a732f683ef466bee062e65c925e3cabc3d033adf325658d43e889f806
+media.map.cameroon:
+  path: ug-map-cameroon.png
+  sha256: 961b84016a86f39443fa0175830c7cca17f88dfabaf88ef5321995357239dec7
+media.map.canada:
+  path: ug-map-canada.png
+  sha256: 206103673a6cc2ae74425a586c7a74e451fc407a198db3becc493c5e6b3b2391
+media.map.canary-islands:
+  path: ug-map-canary_islands.png
+  sha256: cf1874cd6375540e054f9784858b0dcd33226b1bb0dfc4b754375aaa0c208853
+media.map.cape-verde:
+  path: ug-map-cape_verde.png
+  sha256: 67626ddfe9bc1cb8de902eab5cebb26c404204f28c227fb1faf8c10b0b51967e
+media.map.caribbean-sea:
+  path: ug-map-caribbean_sea.png
+  sha256: 7a51abb854ec67f1522afc383b02cf09842706b01195cd8788b21d1cd0050cd5
+media.map.caspian-sea:
+  path: ug-map-caspian_sea.png
+  sha256: 419132e1ea628fd984623a9d340dcc406f4509dc2872293afc33dd7f0f8e50c6
+media.map.cayman-islands:
+  path: ug-map-cayman_islands.png
+  sha256: 14f41fb2bc1e0d2993676504f16d1d5e57ca1ffb42fd109d144d42fcff148ce2
+media.map.celebes-sea:
+  path: ug-map-celebes_sea.png
+  sha256: a6be651b4836a6d50c4743e237b106cbe535c4592699d630e93018d6f9eeffcb
+media.map.celtic-sea:
+  path: ug-map-celtic_sea.png
+  sha256: c317484ca1c7703a6737beb3a94df504cdfa3a6d79488b6ff493a52f427bc162
+media.map.central-african-republic:
+  path: ug-map-central_african_republic.png
+  sha256: e82aa04a179bd09e5219add80aedf0628155aa1ad00e4fa4c2d47edea96be422
+media.map.chad:
+  path: ug-map-chad.png
+  sha256: 3798b6469a2de1ee1b8ce90fb54b7285dc7eb42fb4454ac3f6b98345b84605f4
+media.map.chile:
+  path: ug-map-chile.png
+  sha256: 2bf57a075ab9e69d6d93e35019e4f1665a550d10e0a62a1b7f40132a8066efbd
+media.map.china:
+  path: ug-map-china.png
+  sha256: 04256626f4beffcf18b5bb433b2a37b9e5804c6af48f2eba9c020842940d601f
+media.map.colombia:
+  path: ug-map-colombia.png
+  sha256: 3d7a50170fadf16f2283850826035f167043b5d8596b08f7bd51eed19db2ee40
+media.map.comoros:
+  path: ug-map-comoros.png
+  sha256: 28dc7fc1ed02dd33d3bd856f1b8d1218e8022973d086b835ee855e67122855aa
+media.map.cook-islands:
+  path: ug-map-cook_islands.png
+  sha256: a980209a0414c741d79e07dfe067182236088f0b5df8b60b2e091e70639c1119
+media.map.coral-sea:
+  path: ug-map-coral_sea.png
+  sha256: f1cb9bbcf8b2a1ff6b11a8d21fde0c1eec2beeefc6e0cf91cb4a8fcc6d668d2a
+media.map.corsica:
+  path: ug-map-corsica.png
+  sha256: ebaf1c0e8067c016c90207f42ef17fc49fd904c9ecd16ade11d507b8df9ae1c4
+media.map.costa-rica:
+  path: ug-map-costa_rica.png
+  sha256: 982a9e7eddcc6d8a7547a4b80309ab1bf333a7f9d35c6d3f6ecfcae2c4eea7c6
+media.map.croatia:
+  path: ug-map-croatia.png
+  sha256: 30af7beb8dee6d845a68f68e37c80cbc27a9684f593cd524360b08201666cf95
+media.map.cuba:
+  path: ug-map-cuba.png
+  sha256: 92bd413109f6ae8fd8882e95d41dc4770605d53073cd2aebdbff39f76d6878bb
+media.map.curacao:
+  path: ug-map-curacao.png
+  sha256: 8344aee97a6f9ca2860e814bc79a355e88072bee8dc8631bd162629068df6d9c
+media.map.cyprus:
+  path: ug-map-cyprus.png
+  sha256: dd0535040787778760081faf78abacdbbd4d76a41c991caa483f76473dbacd14
+media.map.czech-republic:
+  path: ug-map-czech_republic.png
+  sha256: aea762a36fd164115acf1e281164e5f7df8b0465bc83fecbf6a68e75061c4a5a
+media.map.dead-sea:
+  path: ug-map-dead_sea.png
+  sha256: 59de292c48517d7d9ce01501f1dc3d52200c7d980548676f92beae5825c27141
+media.map.democratic-republic-of-the-congo:
+  path: ug-map-democratic_republic_of_the_congo.png
+  sha256: 1135be5909235811df9c26f912c2524e4bb06eda97d24471769d3140e3f9fcd4
+media.map.denmark:
+  path: ug-map-denmark.png
+  sha256: a915e6a1fdf6a5ef3d3b2b1d50a036ef5f914a0ae4a06a8da0dc831732c3b51a
+media.map.denmark-strait:
+  path: ug-map-denmark_strait.png
+  sha256: fa8b39196dbf8d2f9708166b7d9274f9cccbe5c6ef994fcca469ec166058f024
+media.map.djibouti:
+  path: ug-map-djibouti.png
+  sha256: 5ae0c0c258857e974dd974d7517c59fda6c96fcf93a767a885bcc81f1452ca3b
+media.map.dominica:
+  path: ug-map-dominica.png
+  sha256: da2d6770b73b912472b565bdf9c800dd7ff1f1d2c7ab4b9f3259bbc9e537bf92
+media.map.dominican-republic:
+  path: ug-map-dominican_republic.png
+  sha256: 8c634fc7f9e40f340d703044923d8cd43ced975835bff6e5e358c27440503b0e
+media.map.east-china-sea:
+  path: ug-map-east_china_sea.png
+  sha256: d85ff238967ecd8ab17c83d563d36033b2a4e5961829b5f95d8df43c5870951f
+media.map.east-siberian-sea:
+  path: ug-map-east_siberian_sea.png
+  sha256: 271d1373c020714e03269e0ac5f3d4209e546546b72e261b08de64183984b8d3
+media.map.ecuador:
+  path: ug-map-ecuador.png
+  sha256: 5728c29fa173dcd8987de46ecf01f22bd16a9a3eb346e0b4736ed67f19289932
+media.map.egypt:
+  path: ug-map-egypt.png
+  sha256: ba2940d2e7bbb47180b9f94fa49f690bc002ec285363821bbb0263986b53686b
+media.map.el-salvador:
+  path: ug-map-el_salvador.png
+  sha256: 2b64afadfdb73b68ba2ed73e41069184a4c807a6ef9bccc25e90f0d23b99a631
+media.map.england:
+  path: ug-map-england.png
+  sha256: bb21306114ae32c39b5855c4a1a6acdd3fca347c63dfaa18fa6483b0c53493af
+media.map.english-channel:
+  path: ug-map-english_channel.png
+  sha256: 99022be732afc78eb827517502f3aeaeb44d37f8322e108cd7f8fc636d28d5c1
+media.map.equatorial-guinea:
+  path: ug-map-equatorial_guinea.png
+  sha256: 59ff8c07c712778c54845edad59b6ed980c0863b0fb913b6cc50eb37a1222915
+media.map.eritrea:
+  path: ug-map-eritrea.png
+  sha256: 3bcd5314f2ef73ce5e0191410279eb0876b54c4de56cb04088a32b2325c93842
+media.map.estonia:
+  path: ug-map-estonia.png
+  sha256: 176613374951ddccc0aff18cfd9cf6f4f69d6e53417928cc939d75d2f45f6bf3
+media.map.eswatini:
+  path: ug-map-eswatini.png
+  sha256: 5e149d49522a3be1417199222ff6cc883ea8b61bda929ec26a31d6986e23eb21
+media.map.ethiopia:
+  path: ug-map-ethiopia.png
+  sha256: ee198b399013d05067d18230351ffbe46d92cc8ad9705633f7cb554dcb8f9954
+media.map.europe-nobox:
+  path: ug-map-europe-nobox.png
+  sha256: bd9340188201a899ca3e8f932d6b2eadccceda797cadf04f51aa4441d95edba2
+media.map.european-union:
+  path: ug-map-european_union.png
+  sha256: 2bd4689e891f4fb90c5ec7af6fc7bc38823c7098b81563742ae7846df9a6eee8
+media.map.falkland-islands:
+  path: ug-map-falkland_islands.png
+  sha256: 67a5f330088cbb49e49363cc1fffebb422c72f14e794a5b86525f2634acb3cf1
+media.map.faroe-islands:
+  path: ug-map-faroe_islands.png
+  sha256: 5bae13dbdda9cc388eb4975b2142c5a93c2902332d9ee9416b0a873065db0413
+media.map.federated-states-of-micronesia:
+  path: ug-map-federated_states_of_micronesia.png
+  sha256: 661f8e9f933afc852bfac3dea4b3ee50c9165eb7520ec94a16015cfe0219bd53
+media.map.fiji:
+  path: ug-map-fiji.png
+  sha256: 3d764fdcbd631e7c889526d7fc5fce303647fb82b106fcef4bda54484812ebdd
+media.map.finland:
+  path: ug-map-finland.png
+  sha256: 8b363eefa0030fd2e07b5feec57f08100824604f4f13c8378d952b34f6f3ac18
+media.map.france:
+  path: ug-map-france.png
+  sha256: d8b8e39e2231c62de0735f127af5ea22034ad2a4aa7fdf78594ef4a5936b97dc
+media.map.french-guiana:
+  path: ug-map-french_guiana.png
+  sha256: 8e45c51e61fd4366aa857740e6a77e129e6f07c1577726708870c5fe32a6f14b
+media.map.french-polynesia:
+  path: ug-map-french_polynesia.png
+  sha256: 7077053c80e6d1944dc60917e76087cb7acb5bf5dcd58c5ca4e32615fa0179ec
+media.map.gabon:
+  path: ug-map-gabon.png
+  sha256: 13312e5efc00c90b27e255aef0255e9741c2b88b9c5bf0d6af9625d3e0f51f04
+media.map.georgia:
+  path: ug-map-georgia.png
+  sha256: 517c67e06d029526e6f075599dec7659ff0d7ae65d229f6009695b566280507a
+media.map.germany:
+  path: ug-map-germany.png
+  sha256: da5930ccc969b3a8c5be823955db98560575a3dc621302623ddc2559ad5defce
+media.map.ghana:
+  path: ug-map-ghana.png
+  sha256: 770e1c261c6ffa1f3640e62a631c81ecdf1523eed667be93e05770d61fd79290
+media.map.gibraltar:
+  path: ug-map-gibraltar.png
+  sha256: 3329ed15f8bd1e9546911832553d0a91354102fda878e2e021e2268a6a68a2b8
+media.map.greece:
+  path: ug-map-greece.png
+  sha256: e51a0f7237adcb8e2bd4679959337cd143e7ef396cab473b4a76d48fe6d8b357
+media.map.greenland:
+  path: ug-map-greenland.png
+  sha256: 9430d1c9596c6dee3956ae5dfcddd20768cd17a28febc81028eab5d23961dd56
+media.map.grenada:
+  path: ug-map-grenada.png
+  sha256: 348630e2192042c37f2983af70b44143d72630d01276ad8a601dac3010da62e1
+media.map.guadeloupe:
+  path: ug-map-guadeloupe.png
+  sha256: dbabc119081bdde680d95e02c29c3ad68815601467b668b1a9c9be61cedf8e4a
+media.map.guam:
+  path: ug-map-guam.png
+  sha256: c1d513e2b59b1de166f220f89421580ba2b62edd37d7f5a41b5a8aff8c094025
+media.map.guatemala:
+  path: ug-map-guatemala.png
+  sha256: f246de90d944fa87ec2d2be302b5f42d1b9addd4ec37f57c23c21c634a14dd9c
+media.map.guernsey:
+  path: ug-map-guernsey.png
+  sha256: d1423ca5357d3a9d5ed286172e2e97b1cb4ef3119ebf830e5a6e8e770274efb9
+media.map.guinea:
+  path: ug-map-guinea.png
+  sha256: af25653bc7ce696127d4dd3b958d8d98ef523a24e0cd66a2b1f4f00767fef719
+media.map.guinea-bissau:
+  path: ug-map-guinea-bissau.png
+  sha256: 114183d0f3286aa515188d39af068d4f6bbf18b9545640c7e87117dd29b76dec
+media.map.gulf-of-alaska:
+  path: ug-map-gulf_of_alaska.png
+  sha256: ebad130cea0adc6ab7c6b8c161653821d12319a28d8dab06772881ae82652b55
+media.map.gulf-of-california:
+  path: ug-map-gulf_of_california.png
+  sha256: 02764fae93e83da306f38be3d549550e735bb18c55995e5decc3e51a1e1cb84c
+media.map.gulf-of-carpentaria:
+  path: ug-map-gulf_of_carpentaria.png
+  sha256: 1e502fb723bda839554d73b4678c4ddb325fa345521c7d44280304f1ca10a5b6
+media.map.gulf-of-guinea:
+  path: ug-map-gulf_of_guinea.png
+  sha256: 48d7c85356510657139629922c2bc706514658723fa43304c8e92174c1daaf42
+media.map.gulf-of-mexico:
+  path: ug-map-gulf_of_mexico.png
+  sha256: 2cb82c20bd5f04ee838f26425624666f9d343de3a2a3c3daa45f44879bd505bb
+media.map.gulf-of-oman:
+  path: ug-map-gulf_of_oman.png
+  sha256: dcd73fa4656b01ceed59d018f54e69289d8d5c6d6e25d6781d2f963ad055369a
+media.map.gulf-of-thailand:
+  path: ug-map-gulf_of_thailand.png
+  sha256: c5fa35b3b9bb935bf157bf8e7df6913cbe144f17571650901bad97595c3f92f7
+media.map.guyana:
+  path: ug-map-guyana.png
+  sha256: e0d987355e2f6132cafcbf4d706b0ca07c72ed5d7ffd7256002b382e3ad6952c
+media.map.haiti:
+  path: ug-map-haiti.png
+  sha256: 9678aed6ebb24b7153870cb495bc8f8b340962be7f3de96104b4fa08119a7b0a
+media.map.hawaii:
+  path: ug-map-hawaii.png
+  sha256: 9db33c475287c75b57bfc260285972e4ea37c17649c0ff1a074557e0aa44a469
+media.map.honduras:
+  path: ug-map-honduras.png
+  sha256: 54c6744e51b753f1ac9e64d5775b9721c4d5c8910712ce94ca22583dbd1d0df9
+media.map.hong-kong:
+  path: ug-map-hong_kong.png
+  sha256: 89f6753ca8092ee4be9bf5ce6a5d3e367ee3cb8c27b0a779d27fb6fa9416ec16
+media.map.hudson-bay:
+  path: ug-map-hudson_bay.png
+  sha256: 526761a4afb298a8d064a3ef1f880a46d96b8adaf1cf54ada3aa1c90e95bd24b
+media.map.hungary:
+  path: ug-map-hungary.png
+  sha256: b292e7cb07833fc2365dc1127731820ea2a452ee6bd0c828221e5aee95959c7d
+media.map.iceland:
+  path: ug-map-iceland.png
+  sha256: d5552a3b6ea5458de6f2a6e3f0b195ed45e75584c1d2623b4f34f323a4ab6220
+media.map.india:
+  path: ug-map-india.png
+  sha256: 0c78368dd4eb5e839239c21886c90d7bfe2690ad66acf25ccbf338c8b0efa9d4
+media.map.indian-ocean-nobox:
+  path: ug-map-indian_ocean-nobox.png
+  sha256: be88b97674c46c09ccf9f7cb5a3a2c0c3cc37d55588eabc06d7c72efda9d1cf8
+media.map.indonesia:
+  path: ug-map-indonesia.png
+  sha256: ca65ddf6bae7d3039094ddd936249243da1a174973f93a04996735f8eaced932
+media.map.iran:
+  path: ug-map-iran.png
+  sha256: fd9e6259e3b65c9c2cd64a12b05955f6f0953037ecb6884dd1cb284b13982663
+media.map.iraq:
+  path: ug-map-iraq.png
+  sha256: 0fe3151a6f61d63cc2a0cc25f511e6acf9d3b778d52fd9e1c2da49a3208dd192
+media.map.ireland:
+  path: ug-map-ireland.png
+  sha256: cd9e170f22c2b6180bf2967373b1efbeaf97d4c77ac6f1796ec1a43179b62c10
+media.map.isle-of-man:
+  path: ug-map-isle_of_man.png
+  sha256: 7cde0c675f009d6fb1af85958685dec45fde1e080b841e0339ce887971dfc6bd
+media.map.israel:
+  path: ug-map-israel.png
+  sha256: 56bff8041621b05c37057db74d4015424b103640460175991f97946c5de7b814
+media.map.italy:
+  path: ug-map-italy.png
+  sha256: cda64906ae1e819951c8a53da35769564afc0b43159bbd23bfdc911b7d5e7992
+media.map.ivory-coast:
+  path: ug-map-ivory_coast.png
+  sha256: 7f9f49d278099e4ac73ce6db7d9a80e44c984f6fe2e4736ec90150d0894ab563
+media.map.jamaica:
+  path: ug-map-jamaica.png
+  sha256: 81751adc6693e99c86921ad957d71d511961fc20282636ca9525a6627acaa401
+media.map.japan:
+  path: ug-map-japan.png
+  sha256: a183f2cd9379ebf2f1f561d23a53eaee055c46e9a5168029dea23c7ca8ad45a3
+media.map.java:
+  path: ug-map-java.png
+  sha256: 7aab8990349388dfcf74aa9b0449e6db1326f5e87d6331af5c1772cdc1102d20
+media.map.jeju:
+  path: ug-map-jeju.png
+  sha256: 8c32cf5bbcfe5d14440931404cad675e5dce9b909d26a39e9d12bb6c5c3a526a
+media.map.jersey:
+  path: ug-map-jersey.png
+  sha256: 54ef73a581873cc1e5d63cc377ce07cfafb1df85bc4069144a4e9d819e49e1ae
+media.map.jordan:
+  path: ug-map-jordan.png
+  sha256: 3eb3cf08014f899e3bfe42659443d7bacdbebe5e1bf833ae976c65e613e35a9d
+media.map.kaliningrad-oblast:
+  path: ug-map-kaliningrad_oblast.png
+  sha256: 628442e682cbfada6a2551b11229259c3efac6f22e62f01dca5f2965f08104a1
+media.map.kazakhstan:
+  path: ug-map-kazakhstan.png
+  sha256: bb108ab45f166de2082b9a37457eb6fc0a2a0c965d4f7366100f04fda00e9d14
+media.map.kenya:
+  path: ug-map-kenya.png
+  sha256: 91a8b5c45fb0cfe879b4440a55ffe0f5e5cd6c7f977eb16e44cb8e8f9ae4cc3a
+media.map.kiribati:
+  path: ug-map-kiribati.png
+  sha256: cfa6dc5afff8b5a945fc87e775c2ef53a996524adb1fa8c86910069ae7f2fe03
+media.map.kosovo:
+  path: ug-map-kosovo.png
+  sha256: 985b95f8a972a76ac1fb503b5810c39c5610a20249ca6b44665809678d5120df
+media.map.kuwait:
+  path: ug-map-kuwait.png
+  sha256: d3396afa7200e413ce263f2c461e8e81f84a11a0d440383df8c651cca30e48af
+media.map.kyrgyzstan:
+  path: ug-map-kyrgyzstan.png
+  sha256: 1ed6e418a51caad11d73c993f0757f5241f165429e5bc50c68932b4539623c89
+media.map.labrador-sea:
+  path: ug-map-labrador_sea.png
+  sha256: 12b2d044fcdbe12572312c57a44938e1f1bd1165217a85da08ec2fc8f00a4ef2
+media.map.laos:
+  path: ug-map-laos.png
+  sha256: 2ad5e9a1dd5b3fd8c9d703a28deb0ea29400e2dd4ddf86077342e172f7f062b2
+media.map.latvia:
+  path: ug-map-latvia.png
+  sha256: 55bbca83d2845d9cd74a01882a0ae3d7b817afe8cea10acbcaadb3e10a88c3a7
+media.map.lebanon:
+  path: ug-map-lebanon.png
+  sha256: 052cd63aca5c43d12599b3b4d9ffc37dc44f265c9d8fba311d03048474525707
+media.map.lesotho:
+  path: ug-map-lesotho.png
+  sha256: 0433dd77cc90f1dfc8e58d7866bccf00822d1abf438c4be264e6a485d3e4f91b
+media.map.liberia:
+  path: ug-map-liberia.png
+  sha256: 64f078dcb2ffdabd6e2bfa1a6c5d79ab7e3ec2917ae568748e84a77b8753f150
+media.map.libya:
+  path: ug-map-libya.png
+  sha256: b653b5c52d337c1694b895cc6e84f4a5d5dd96eca159cd2e71a247579944693a
+media.map.liechtenstein:
+  path: ug-map-liechtenstein.png
+  sha256: 3cd2ef43f1e4c15e60d53908752f93d19e96777e9bb8493160a18e2c02e9eff5
+media.map.lithuania:
+  path: ug-map-lithuania.png
+  sha256: e598e9fcbcadb3047ad008c05e3b5d78deedeecf9c4403cdb2e8e10e39b29712
+media.map.luxembourg:
+  path: ug-map-luxembourg.png
+  sha256: 2aac5e141e3c71d786be01476c9f56f94b1559c0104ac9da92a1470434f281b2
+media.map.macau:
+  path: ug-map-macau.png
+  sha256: 7d7917211b730c09f0fdd1c0d0cb2967c8328f3d36dcccff34c4a85397d2a639
+media.map.madagascar:
+  path: ug-map-madagascar.png
+  sha256: 43b459e9ff626bd504e149a1ca33f1b97187e16dc2df8c4d7b676b58f42fb1a2
+media.map.madeira:
+  path: ug-map-madeira.png
+  sha256: f16c44fb8a1b235bee40f96811bcff9d6fde2c9c9b02d9eff5caf5343689f5cc
+media.map.malawi:
+  path: ug-map-malawi.png
+  sha256: 222390dbbe24f9540f9b5102e500fe2865b7a96f66d4221fe050f179b4a12805
+media.map.malaysia:
+  path: ug-map-malaysia.png
+  sha256: 123a5a8d61753b7b52daa2be86056b81704b14d786c1791858cc18a247c35a62
+media.map.maldives:
+  path: ug-map-maldives.png
+  sha256: 481094f5b7b3592a5acb3e6981c54f4f0b352705e09088aed93e55087d2a09bd
+media.map.mali:
+  path: ug-map-mali.png
+  sha256: ed5b13ad4b1ba3ec157ca0c7b20e97e2a0b97bbebe4e3d4fd7a9af6d278873ea
+media.map.malta:
+  path: ug-map-malta.png
+  sha256: 24379ae1d88a8c1415b44b98990233502001868feb011aaa95c85d43da9370bf
+media.map.marshall-islands:
+  path: ug-map-marshall_islands.png
+  sha256: d792dc463bf6c1eb516ba2befff6811e44bf75152f034f54049fe4b00348baf0
+media.map.martinique:
+  path: ug-map-martinique.png
+  sha256: 32f319fdf03395d4d91ea6256c80cdc97f899bbacec2ea027e338e59c0da16d2
+media.map.mauritania:
+  path: ug-map-mauritania.png
+  sha256: 721b14137e8e3e032079c017d49c1105d0055a8184efe2e1b0717e2412650a33
+media.map.mauritius:
+  path: ug-map-mauritius.png
+  sha256: 77ac1688af86648fc3c0f6fd1f312e6f4dd7ed85e187d38abd949711ecb19f6b
+media.map.mayotte:
+  path: ug-map-mayotte.png
+  sha256: 3d7842b876520d1a8eb7dfab1727998cbdffff62910340dffeb9237637c19db1
+media.map.mediterranean-sea:
+  path: ug-map-mediterranean_sea.png
+  sha256: 1331b77ee6fd7256ee8ee30798c40b5ca2061cbde8664e05ea27d2693c08ad4f
+media.map.melanesia:
+  path: ug-map-melanesia.png
+  sha256: bd23f439bca2ea3e9f1ceab13d343baf9b4a56a11c919b3fb2c85ae4388051ff
+media.map.mexico:
+  path: ug-map-mexico.png
+  sha256: 8484a49dbe17985e5faa54d549f83eec322106fbb6d5d56e2e00cd704bb94606
+media.map.micronesia:
+  path: ug-map-micronesia.png
+  sha256: c0649b23ec9301bc9ff0ce546ede24ccd92d9afbf09820b322fa8ce1897430f8
+media.map.moldova:
+  path: ug-map-moldova.png
+  sha256: 27c1c3393923d4121ba6d2e852cf5c99dabc2ddf7caeeb3f0c15b2b2f5fff1f6
+media.map.monaco:
+  path: ug-map-monaco.png
+  sha256: 38149fa13338f45b99041a6e3485f15996e405d91053203da51dccc15f3ff884
+media.map.mongolia:
+  path: ug-map-mongolia.png
+  sha256: 09201f4c71d87d3b9d2b403e8b3adf2d93da4a09c7259f4742d8d9385508f275
+media.map.montenegro:
+  path: ug-map-montenegro.png
+  sha256: 417dd70a88419df409f6d76ec144db61179f625f31c41ff1dc75736338c9c04c
+media.map.morocco:
+  path: ug-map-morocco.png
+  sha256: 740a2725ff6e9f1eb2b157b02e186d32f8aada5cb8333742e194e29999582c77
+media.map.mozambique:
+  path: ug-map-mozambique.png
+  sha256: 5acb3fc7288c6984dfff83412eb51bff51c02877af531578ee16e2878eec6b2c
+media.map.myanmar:
+  path: ug-map-myanmar.png
+  sha256: ef6f913a7b62eac0cc9e82463ef45d6ed5e74d1fceaee0a541bddff31b4687d0
+media.map.namibia:
+  path: ug-map-namibia.png
+  sha256: 25e329aaf7474fec794035ff6976532c01033a2a7c6b5339abc84bd440517486
+media.map.nauru:
+  path: ug-map-nauru.png
+  sha256: a444a295a2bf261d16e4ae9ef172dd90fa58b46c25170f7eb68921796cca5e83
+media.map.nepal:
+  path: ug-map-nepal.png
+  sha256: 5098c3e9104fb056342dce1d12c28ebe81047557e3f2a15e43a7b6e53cada480
+media.map.netherlands:
+  path: ug-map-netherlands.png
+  sha256: 4c9d5f17713d8c357b4fcf568e8229081d0ebeb4df4474c67543371dfac3ad73
+media.map.new-caledonia:
+  path: ug-map-new_caledonia.png
+  sha256: 93f375e5d41512f0a0ebbceca5f1b2ef377eac91a380ed61bf2b90c37206b749
+media.map.new-zealand:
+  path: ug-map-new_zealand.png
+  sha256: f4e264f1f5cb693763493fdf046ffe2a21e043d373e93a11938401e695bdd952
+media.map.nicaragua:
+  path: ug-map-nicaragua.png
+  sha256: 7fbe6e1e23dc6f84bb0fea4d695d598babaf90f7b980cc25729390be655ed03d
+media.map.niger:
+  path: ug-map-niger.png
+  sha256: 64a0a67710824b35a971e3eb44deba0b1d65f033e85c70747ef6d3311f3ab770
+media.map.nigeria:
+  path: ug-map-nigeria.png
+  sha256: 28e12db9cd7c5089e4b46a43d30ed6b82886e3cd6c973bb6ab6b313e5deffd62
+media.map.niue:
+  path: ug-map-niue.png
+  sha256: 79904d982f86127de1fc2bf46116554477d4a0b7cbfb956f827e078f538defea
+media.map.north-america-nobox:
+  path: ug-map-north_america-nobox.png
+  sha256: a7b12df0907f93dd4ac98750b68b25b5a9ccb83ae6e728632e695368437361e9
+media.map.north-korea:
+  path: ug-map-north_korea.png
+  sha256: 7774b1675ed475a22e4c148fdddd00e20be74b6221b0078644646a70a8cd195d
+media.map.north-macedonia:
+  path: ug-map-north_macedonia.png
+  sha256: b014a1b95ecc4cf09019b0a5ab326038575095c668de19767d18516471df917e
+media.map.north-sea:
+  path: ug-map-north_sea.png
+  sha256: b27efe4099722e91f85b795ef02e9af1259678ad93204317a11bc320ec134375
+media.map.northern-cyprus:
+  path: ug-map-northern_cyprus.png
+  sha256: ccffef57583e54ac672f57e830a6bd4efc920254d15a7af60946947fa7b5029b
+media.map.northern-ireland:
+  path: ug-map-northern_ireland.png
+  sha256: 71225adbd7f29893cb088c657266c3aefbd0aa6d4d66b1c78b23ae3e51289da5
+media.map.northern-mariana-islands:
+  path: ug-map-northern_mariana_islands.png
+  sha256: 96f2b1f57caa60682c74c8aa4fcb8cd36e2d1a9c720f7b52f958d240c9a1cff3
+media.map.norway:
+  path: ug-map-norway.png
+  sha256: 8190fd99ca40845c1a1572c0f658c3f4772989df2aed47b6af64dc6805c5aa60
+media.map.norwegian-sea:
+  path: ug-map-norwegian_sea.png
+  sha256: afde47fffd4d9fd92f7de20e7d301b0d3d4271672d8809ef5442f47f9c41e963
+media.map.oceania-nobox:
+  path: ug-map-oceania-nobox.png
+  sha256: f691fd61adcac94221ab07a601e3725f20044a9947255357f282345b1f389571
+media.map.oman:
+  path: ug-map-oman.png
+  sha256: 7f49b7323727cb4e7e3d30c55f9d07d437a2f26aec4dfaf87ede0b2b6f8bd859
+media.map.pacific-ocean-nobox:
+  path: ug-map-pacific_ocean-nobox.png
+  sha256: e2440ef07526c63feed974957ac5908e37d3586cda6ac98fc92096b7a2c09a7c
+media.map.pakistan:
+  path: ug-map-pakistan.png
+  sha256: a3d0d23796848368ddbb04782bab1d92d704214a3285717bbad6018a7340ba8c
+media.map.palau:
+  path: ug-map-palau.png
+  sha256: 28420e9936aede4699f62be4221906328fd13b9cb8763edcafa6ce529c64cae9
+media.map.palestine:
+  path: ug-map-palestine.png
+  sha256: b7909a0c208dbe104b20a603eb1b7b44691fd7fab4a1c799efcba4c3f33b1078
+media.map.panama:
+  path: ug-map-panama.png
+  sha256: 62ee01ee226945e15088ae83f55b02188e3f2f81dde1c37a21b37a2fd03c623a
+media.map.papua-new-guinea:
+  path: ug-map-papua_new_guinea.png
+  sha256: 7aba2964ca9b65ca04cf3d52b1b82a2de9d812e0ea4cc32ef4f0ea4bcda0c599
+media.map.paraguay:
+  path: ug-map-paraguay.png
+  sha256: 0370e8692ea1d934eeb7c7fc71b01bdbb4b3351755f995a767c5a8fe8936fd61
+media.map.persian-gulf:
+  path: ug-map-persian_gulf.png
+  sha256: 5ccbd59d8320b20b53b628498b91ac6d26d6f6a520273885ea3bc16b58ed31cd
+media.map.peru:
+  path: ug-map-peru.png
+  sha256: d72dc3b2c92e08dbf7dd3eb5b1be324fc12736d2a50924a09c465318120cf2b0
+media.map.philippine-sea:
+  path: ug-map-philippine_sea.png
+  sha256: fbb58f43a91dfc362d5fceb7530dec6cd397971c4fc1e6b0e98f86ec4dd5a475
+media.map.philippines:
+  path: ug-map-philippines.png
+  sha256: 77e1e81ab3ba1631c929265e8b470078d5e058e1ffb3c23e653d990ee289070f
+media.map.poland:
+  path: ug-map-poland.png
+  sha256: 5d92e688e8624b081054c57425e6c7cef87b327665b262080f6015dbe3eaa6ba
+media.map.polynesia:
+  path: ug-map-polynesia.png
+  sha256: daeb95dab60d413407d0311032333e3ee06dea791ba725de9e83eb688c872b48
+media.map.portugal:
+  path: ug-map-portugal.png
+  sha256: eb579e5bd7f329aa4a187f7d621c3149a56fe21d2b1a53acab38c9b1b91491fb
+media.map.puerto-rico:
+  path: ug-map-puerto_rico.png
+  sha256: de24c4c6af6d7f801794f34b61c02e67cd5125c5a36860c488fbf17f141138bb
+media.map.qatar:
+  path: ug-map-qatar.png
+  sha256: 66d65432c64c7ead752e49b789a276824426b4fa9333127f40e7487fe12ee3ed
+media.map.red-sea:
+  path: ug-map-red_sea.png
+  sha256: 57a9bf0ead55daf043a807f32f521cbc4a4f6b72bbf78de6cbe7385d8920dcf1
+media.map.republic-of-the-congo:
+  path: ug-map-republic_of_the_congo.png
+  sha256: 0b6266b39a4a113b51ee034792fe83008ef6ca720cbc9439bc872d16afd1705d
+media.map.reunion:
+  path: ug-map-reunion.png
+  sha256: 926f7839df46515d8b2a7f0e9ecce487188b11d2ef0d991d86bb3ea04daa7f7b
+media.map.romania:
+  path: ug-map-romania.png
+  sha256: a117652db709a6869dd7edb323946b4447cad41edb0f0783a5c1caf822b5efb7
+media.map.russia:
+  path: ug-map-russia.png
+  sha256: 6882caeab6eca32c0c1e7ecb77542ced5d0682f52aec9db9bb11b1ba65b35966
+media.map.rwanda:
+  path: ug-map-rwanda.png
+  sha256: b7c31c1136823475b00bdb2775725a856d13e2ed371da2d8749bafe052ceba44
+media.map.sahrawi-arab-democratic-republic:
+  path: ug-map-sahrawi_arab_democratic_republic.png
+  sha256: 3991957c2f6fd8cd5cd67b82927e999557666cf0f94095f4cf44ea4e4dcc2156
+media.map.saint-kitts-and-nevis:
+  path: ug-map-saint_kitts_and_nevis.png
+  sha256: 4b89a7fac320e9f1ca0254b52b65230949168dcd20bd0d6e3a55655aa6755eb3
+media.map.saint-lucia:
+  path: ug-map-saint_lucia.png
+  sha256: 81bbfc4f42c022a13d0d7f3e3146361f6a5c06e859de421ed554232d0a95cd99
+media.map.saint-martin:
+  path: ug-map-saint_martin.png
+  sha256: 181b5dec16a06e13d2e5a16f7a837dba636347d3e2b51cb606681c6eaf4dd39f
+media.map.saint-vincent-and-the-grenadines:
+  path: ug-map-saint_vincent_and_the_grenadines.png
+  sha256: e75a461123b07a3aea01886cff5377154daf16cb203840e9273003116948d004
+media.map.samoa:
+  path: ug-map-samoa.png
+  sha256: 55457079b15b3dd862f41697ed486ba10d9370f27689ba7525228a7f4b69ac20
+media.map.san-marino:
+  path: ug-map-san_marino.png
+  sha256: 391730072b9b3136fef5db837244d830d9efd54642f7059be8403fa756ab4bcd
+media.map.sao-tome-and-principe:
+  path: ug-map-sao_tome_and_principe.png
+  sha256: 10ddb21964a6dfbfdac52ca415bd4da452586840d90985545c4e657e778c0b09
+media.map.sardinia:
+  path: ug-map-sardinia.png
+  sha256: 25c42c7419608daec95bdbb2023f7e8baccc105ed576aec139cdeb26fcc9023e
+media.map.saudi-arabia:
+  path: ug-map-saudi_arabia.png
+  sha256: a26fb735c45428de84618bc9429bc1eead8db7dd854785178b791d6561ba036c
+media.map.scandinavia:
+  path: ug-map-scandinavia.png
+  sha256: 06b2e72381227e8471f2c792e740693024aac9b6623e9811ff87c1de238dc2fb
+media.map.scotland:
+  path: ug-map-scotland.png
+  sha256: 0dec6c0218e364bd84d43b4b8a4a491363aa5fc34e8d93b1ad834b5547d2edcf
+media.map.sea-of-galilee:
+  path: ug-map-sea_of_galilee.png
+  sha256: ded52dbc6de2c3fe2e37ea237d84cc101d55eab4e5a70b04304b5d4e167f70d9
+media.map.sea-of-japan:
+  path: ug-map-sea_of_japan.png
+  sha256: e5aa427092eaffe1226756785a0cb3b83f836cf2e5ef41d6ad192b07300888f1
+media.map.sea-of-okhotsk:
+  path: ug-map-sea_of_okhotsk.png
+  sha256: 77dcaf43e27a45b554f02c881ccbcc178b07b4dabb62220173298d601848856e
+media.map.senegal:
+  path: ug-map-senegal.png
+  sha256: 5643a4b95e250d431032f816792f9ac5f4703bc6792c0a481b25032ba79f057a
+media.map.serbia:
+  path: ug-map-serbia.png
+  sha256: 9cae220b99eaf346be259609242bdc620807ff7f111adfc7c9dfc1b7e31dda31
+media.map.seychelles:
+  path: ug-map-seychelles.png
+  sha256: b723ce58344762a1e9694c30c3ef0d8106d0459c0662444f45bd1bdc56831019
+media.map.sicily:
+  path: ug-map-sicily.png
+  sha256: 50d07ff799135afd433c412e5b81c81174b58a071e5794ceec27e9d88bf0b4f9
+media.map.sierra-leone:
+  path: ug-map-sierra_leone.png
+  sha256: 98829ede64e879cd20a3cd041d3f1819f0b867ceab0c0bccd5033ccdf23abaae
+media.map.singapore:
+  path: ug-map-singapore.png
+  sha256: 5fb367fbd8ef77777e386f059e792c6d3699520f30d688288048b0f592bb22bf
+media.map.sint-maarten:
+  path: ug-map-sint_maarten.png
+  sha256: b5c4cfa2ff5518e3e3982acfffc1e5876254e912e2c67a2d3c9af0abe2679fa3
+media.map.slovakia:
+  path: ug-map-slovakia.png
+  sha256: 336beb69f315014f2d0d8ff8722a9bc39f492fe0a1370395b9c2cf49bb251e13
+media.map.slovenia:
+  path: ug-map-slovenia.png
+  sha256: 370fed739bba62d59fea715aa09eeeea3a5ca47ddca4637844a698f82be588b5
+media.map.solomon-islands:
+  path: ug-map-solomon_islands.png
+  sha256: 2a7f48a03769b3e51e0ec964b1214fc040fc8fee9249a98dcbc81d3873d72f7c
+media.map.somalia:
+  path: ug-map-somalia.png
+  sha256: 9fb69c2ff9e7b6006046d7bbd4901e4e224c17372b792f86d139cfce1dbb9b36
+media.map.somaliland:
+  path: ug-map-somaliland.png
+  sha256: 831383b79f7b884dfa31af184f6b4dd3c43af967260803afc69cca77462b6d8a
+media.map.south-africa:
+  path: ug-map-south_africa.png
+  sha256: 92ffaa0b9ff129ba4c37f0337d4fe466d945e03c76f799bf47480b271453f7b1
+media.map.south-america-nobox:
+  path: ug-map-south_america-nobox.png
+  sha256: b64c81754e2c13a4b96825ed67139a9607d0db6d45ced6c56cc5b217508bcbe5
+media.map.south-china-sea:
+  path: ug-map-south_china_sea.png
+  sha256: 9d6e0c9f01930e12c7258378d9321fbbbbb8d66a44c617bb15585ae873c87b2f
+media.map.south-korea:
+  path: ug-map-south_korea.png
+  sha256: 8df679b31dbef5dcdfef1641819589e9b3603d8c8e74eb2b2bd84bbaee889a88
+media.map.south-ossetia:
+  path: ug-map-south_ossetia.png
+  sha256: e673922827b43bda05150b1aec007b1b2c765226987ecefa14dd870448b0423e
+media.map.south-sudan:
+  path: ug-map-south_sudan.png
+  sha256: cb5db574d217983c2fd8d86a62e4b50006b2e6441015c7b1208b25df9afd9662
+media.map.southern-ocean-nobox:
+  path: ug-map-southern_ocean-nobox.png
+  sha256: ea14590f235284ada45f8d0dd3277ad6a5a2c7909356711f8d5a223ec5a8c180
+media.map.spain:
+  path: ug-map-spain.png
+  sha256: 0050a7882c791beca40d40f057b44f29563bce617cd8fa45e36eee6d603b2bb0
+media.map.sri-lanka:
+  path: ug-map-sri_lanka.png
+  sha256: 5a6ff8f51e8442340e3e82b264f70066756db3bcf9ae39e9572887a9771b56b1
+media.map.strait-of-gibraltar:
+  path: ug-map-strait_of_gibraltar.png
+  sha256: 29a63221ea82dfbf99369d8e152e5b456aa40266bf7da5f4a1464fdbb47fa7d6
+media.map.strait-of-hormuz:
+  path: ug-map-strait_of_hormuz.png
+  sha256: dcbb93119404e07d0a2aef6190dd5917a13db19e3d5a880e498547577d0edf41
+media.map.strait-of-malacca:
+  path: ug-map-strait_of_malacca.png
+  sha256: a5f421802d0f8e8f1cd38577a9b8331beb2adb937e7fbe5e07f11a937803b2c7
+media.map.sudan:
+  path: ug-map-sudan.png
+  sha256: a2d8c4b441c3007d99423f024c19b998fd8a01d98f48e756b1129eb2349f99fd
+media.map.sumatra:
+  path: ug-map-sumatra.png
+  sha256: c411028a1775d44786f2eaa166208cc7372b4e3997a119c1c22b6b5208089a23
+media.map.suriname:
+  path: ug-map-suriname.png
+  sha256: ff384a222f6f9dcc6526b7142c70233f97cc34a72dc8d9d985963e9f44912d0a
+media.map.svalbard:
+  path: ug-map-svalbard.png
+  sha256: b0c74444bb5c838ae6b3553827692f5ff56fd62710f6e4e3cc520843e12a8631
+media.map.sweden:
+  path: ug-map-sweden.png
+  sha256: 63542aa8fc76afcc5f3bebb3396f63e686173e842c771cac50343bc5087f7d8a
+media.map.switzerland:
+  path: ug-map-switzerland.png
+  sha256: 9898b63d2e6090bb2a986c24baa8727cca780c9488a6de8f631a2700d0bcb2b3
+media.map.syria:
+  path: ug-map-syria.png
+  sha256: d65a1f684d182e2851c1960f73547c4e29b1438d6a1bbb48b5400c8b96a7294c
+media.map.taiwan:
+  path: ug-map-taiwan.png
+  sha256: cf150de2ccb5e512c8327193aa3b6701a7d53840adcd29a324b94c71e2d69d99
+media.map.tajikistan:
+  path: ug-map-tajikistan.png
+  sha256: 235a84bd5b5e0070e4e8aee02be7f676a8864a432cfaab2df3cc222f4e67d24b
+media.map.tanzania:
+  path: ug-map-tanzania.png
+  sha256: 61be16eb51c4b2f7253acade12a7aa2a940c860133d9fbb521ddbeeb11bf98d4
+media.map.tasman-sea:
+  path: ug-map-tasman_sea.png
+  sha256: 3e1102c19f60b70ec572a7d9d2631a510678badb22a35bed32cd4e65c456caa2
+media.map.thailand:
+  path: ug-map-thailand.png
+  sha256: 764d9f46b980e999ad19f2d0bbf9a3d7043b39f4002a6ce9a71824b0927c1028
+media.map.the-bahamas:
+  path: ug-map-the_bahamas.png
+  sha256: a8fbd4887a49261e14b092c174f8d5496ef6ec48a9a8a3c40c471fb359ff7416
+media.map.the-gambia:
+  path: ug-map-the_gambia.png
+  sha256: 366da5c9ad432b65838cc6fcd1fe9b226b1c2fb305594a447bafc48b8a24bad1
+media.map.timor-leste:
+  path: ug-map-timor-leste.png
+  sha256: ed14ed25a08d33b2a517930babc263f6541b0c4a78be351c0365d7d0c7bb7949
+media.map.timor-sea:
+  path: ug-map-timor_sea.png
+  sha256: 0b099536921576c23feea5fe71a39eb86af787f7c373e24632f9578546482fdd
+media.map.togo:
+  path: ug-map-togo.png
+  sha256: dfd061f37d5d620dec5682e2cc7ef38a097bf08597dc31d05b638c867276f566
+media.map.tonga:
+  path: ug-map-tonga.png
+  sha256: 4c6a44205895071ad95ff96b054f2491a461870b8fec3c3dfe6b4bcf25611520
+media.map.transnistria:
+  path: ug-map-transnistria.png
+  sha256: 62b03eb9ca53861804ff3dcc34f07294ffd598e98e0166d6bbce5e12afdc3dcf
+media.map.trinidad-and-tobago:
+  path: ug-map-trinidad_and_tobago.png
+  sha256: f0cf26b19efd2034110276d2577f941f36c22bff43b87b90fea7073da20d7d4b
+media.map.tunisia:
+  path: ug-map-tunisia.png
+  sha256: 922f7f905c2e0769e40fb210609cdcaccce7ce69b9a98182fb88c032cd94a504
+media.map.turkey:
+  path: ug-map-turkey.png
+  sha256: 9f2a2628438e97bd427b6e5501090c978623138622afbded2100d590e6bd507e
+media.map.turkmenistan:
+  path: ug-map-turkmenistan.png
+  sha256: bc37eaefe4d7adc0976adb443d461eed2880cc1cdb91538e69d4fce1a55bdacf
+media.map.turks-and-caicos-islands:
+  path: ug-map-turks_and_caicos_islands.png
+  sha256: bf647c542dc8ba2e007e1c1dda84e356bfba4fcd8dbd5cbc99957a7a09d168a8
+media.map.tuvalu:
+  path: ug-map-tuvalu.png
+  sha256: ef3367bc12c1f65bc06a91a9a8c41bb367bf07f0ed5004490eb83938f371caa7
+media.map.uganda:
+  path: ug-map-uganda.png
+  sha256: 62972a032d58d8c4a082a504a011e8062bd2ea7e07558616828b71bc5ccc5410
+media.map.ukraine:
+  path: ug-map-ukraine.png
+  sha256: c7c6ef8070c5e3b6eac96fd12944d111d38c8cc50a57f2b2139078e9d47d8b02
+media.map.united-arab-emirates:
+  path: ug-map-united_arab_emirates.png
+  sha256: e75223ef1bce0b072d700529269d2b30aeee20a6ee70f47495618f80da9df895
+media.map.united-kingdom:
+  path: ug-map-united_kingdom.png
+  sha256: a004b406c1572bef213b0428aba6894ea4b0c0141cf1d0a6ad75f3ad0564a14c
+media.map.united-states-of-america:
+  path: ug-map-united_states_of_america.png
+  sha256: ab66f67415b64b9a55af5bdc34997b3e689812a51f5fe1e5776d05551029c200
+media.map.united-states-virgin-islands:
+  path: ug-map-united_states_virgin_islands.png
+  sha256: 0bfa05ed8026e012164f68dc8a764cd9a628d85b5b09fadc45ebc04c49433078
+media.map.uruguay:
+  path: ug-map-uruguay.png
+  sha256: a459a8f6b2091d3691d25345dcee3706ddbe4311f57dc7b444d472d5d653f987
+media.map.uzbekistan:
+  path: ug-map-uzbekistan.png
+  sha256: a73bcd435a6161076b25be3d5cda03923509ef11f5b6d697e7e37dccb4ea2ac1
+media.map.vanuatu:
+  path: ug-map-vanuatu.png
+  sha256: 1db05132b77e0db0783c9dc17c0dbbfa981fec16185fcb185d93852db86051c2
+media.map.vatican-city:
+  path: ug-map-vatican_city.png
+  sha256: 8aec73232034aa53b24471c63e4e0bb10a70a385aec7a706d775ec93f5b49993
+media.map.venezuela:
+  path: ug-map-venezuela.png
+  sha256: 65067db5d65ee24ed1518b2f0851e21c21b6896efac2cbb2f991b484a5a8e1b3
+media.map.vietnam:
+  path: ug-map-vietnam.png
+  sha256: 83ed4280e9c0edfe253a484d0be24cc617cfc128ea5c599faaaaeb470bd3353a
+media.map.wales:
+  path: ug-map-wales.png
+  sha256: 85585abb3384ce9051370c79e957c426afc9730957715e0296a1b7f3b71e178b
+media.map.wallis-and-futuna:
+  path: ug-map-wallis_and_futuna.png
+  sha256: 75f514c1268cb35c1624f1df3d8710435e1bf537edb5e5f0b491e9a2c4053bc6
+media.map.white-sea:
+  path: ug-map-white_sea.png
+  sha256: 831a2aeb483fe193d1dd89d704dbdde5c7d59935c621e3a89176378132e4100e
+media.map.yellow-sea:
+  path: ug-map-yellow_sea.png
+  sha256: bb59efe3c65e43977fecedacf8830b72c4f9b96eaf914f3f85ec9b0019352576
+media.map.yemen:
+  path: ug-map-yemen.png
+  sha256: adc8005d44806a163046804a0a179544f8c3f36ac49d250b9142289fa0376548
+media.map.zambia:
+  path: ug-map-zambia.png
+  sha256: 0d453c22d13de6681a591ea124daaf8cf65ce7b35f63b2db5fc141e7dece7900
+media.map.zanzibar:
+  path: ug-map-zanzibar.png
+  sha256: b4f93c49f201b5383d5383d74682f145b9eb572c63cbe6cbb8fd1c24a31bf772
+media.map.zimbabwe:
+  path: ug-map-zimbabwe.png
+  sha256: 1419aba8cf9639fcd5d5a15efbac130ca8c8872e4ebc858d0bfc9df97746f34f

--- a/migration/brainbrew/compare_crowdanki.py
+++ b/migration/brainbrew/compare_crowdanki.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compare two CrowdAnki export directories without serializer-order noise."""
+"""Compare CrowdAnki exports, normalizing unordered notes and media declarations."""
 
 import argparse
 import hashlib
@@ -34,6 +34,25 @@ def _unique_object(pairs):
     return result
 
 
+def normalize_notes(deck, label):
+    notes = deck.get("notes")
+    if not isinstance(notes, list):
+        raise InputError(f"{label}: notes must be a list")
+    guids = []
+    for index, note in enumerate(notes):
+        if not isinstance(note, dict):
+            raise InputError(f"{label}: notes[{index}] must be an object")
+        guid = note.get("guid")
+        if not isinstance(guid, str) or not guid:
+            raise InputError(f"{label}: notes[{index}].guid must be a non-empty string")
+        guids.append(guid)
+    if len(guids) != len(set(guids)):
+        raise InputError(f"{label}: notes contains duplicate GUIDs")
+    normalized = dict(deck)
+    normalized["notes"] = sorted(notes, key=lambda note: note["guid"])
+    return normalized
+
+
 def load_target(root, label):
     if not root.is_dir():
         raise InputError(f"{label}: target directory is missing")
@@ -51,6 +70,7 @@ def load_target(root, label):
         raise InputError(f"{label}: invalid deck.json: {error}") from error
     if not isinstance(deck, dict):
         raise InputError(f"{label}: deck.json must contain a top-level object")
+    normalized_deck = normalize_notes(deck, label)
 
     declared = deck.get("media_files")
     if not isinstance(declared, list) or any(type(name) is not str for name in declared):
@@ -61,6 +81,7 @@ def load_target(root, label):
         path = PurePosixPath(name)
         if not name or path.is_absolute() or ".." in path.parts or "\\" in name:
             raise InputError(f"{label}: unsafe media filename {name!r}")
+    normalized_deck["media_files"] = sorted(declared)
 
     media_root = root / "media"
     if not media_root.is_dir():
@@ -92,11 +113,19 @@ def load_target(root, label):
         tree_digest.update(b"\0")
         tree_digest.update(bytes.fromhex(digest))
     return {
-        "deck": deck,
+        "deck": normalized_deck,
         "deck_size": len(raw),
         "deck_sha256": hashlib.sha256(raw).hexdigest(),
         "canonical_sha256": hashlib.sha256(
             json.dumps(deck, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+        "semantic_sha256": hashlib.sha256(
+            json.dumps(
+                normalized_deck,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
         ).hexdigest(),
         "media": media,
         "media_tree_sha256": tree_digest.hexdigest(),
@@ -148,8 +177,12 @@ def compare(legacy, candidate):
         f"{'identical' if legacy['deck_sha256'] == candidate['deck_sha256'] else 'different'}"
     )
     print(
-        f"canonical JSON sha256: legacy={legacy['canonical_sha256']}; "
+        f"canonical JSON sha256 (original note order): legacy={legacy['canonical_sha256']}; "
         f"candidate={candidate['canonical_sha256']}"
+    )
+    print(
+        f"semantic JSON sha256 (notes by GUID, media_files by filename): legacy={legacy['semantic_sha256']}; "
+        f"candidate={candidate['semantic_sha256']}"
     )
 
     legacy_media = legacy["media"]

--- a/migration/brainbrew/stage_media.py
+++ b/migration/brainbrew/stage_media.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Verify and flatten ordinary flag/map media for Rust Brain Brew."""
+
+import argparse
+import hashlib
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_DIRS = (ROOT / "src/media/flags", ROOT / "src/media/maps")
+MANIFEST = ROOT / "media.yaml"
+DESTINATION = ROOT / "build/brainbrew-media/standard"
+ENTRY = re.compile(
+    r"(?m)^(media\.[a-z0-9.-]+):\n  path: ([^\n]+)\n  sha256: ([0-9a-f]{64})$"
+)
+
+
+def digest(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def declarations(path):
+    text = path.read_text(encoding="utf-8")
+    matches = ENTRY.findall(text)
+    if "".join(match.group(0) + "\n" for match in ENTRY.finditer(text)) != text:
+        raise ValueError(f"malformed media manifest: {path}")
+    by_path = {}
+    ids = set()
+    for media_id, filename, expected_hash in matches:
+        if media_id in ids:
+            raise ValueError(f"duplicate media id: {media_id}")
+        if filename in by_path:
+            raise ValueError(f"duplicate media path: {filename}")
+        if Path(filename).name != filename:
+            raise ValueError(f"media path is not flat: {filename}")
+        ids.add(media_id)
+        by_path[filename] = expected_hash
+    return by_path
+
+
+def sources(source_dirs):
+    found = {}
+    for directory in source_dirs:
+        for path in sorted(directory.iterdir()):
+            if not path.is_file() or path.is_symlink():
+                raise ValueError(f"source is not a regular file: {path}")
+            if path.name in found:
+                raise ValueError(f"media basename collision: {path.name}")
+            found[path.name] = path
+    return found
+
+
+def verify_source(source_dirs, manifest, expected_count=550):
+    declared = declarations(manifest)
+    found = sources(source_dirs)
+    if len(found) != expected_count:
+        raise ValueError(f"expected {expected_count} source files, found {len(found)}")
+    if declared.keys() != found.keys():
+        missing = sorted(declared.keys() - found.keys())
+        extra = sorted(found.keys() - declared.keys())
+        raise ValueError(f"media set mismatch; missing={missing}, extra={extra}")
+    for filename, path in found.items():
+        actual = digest(path)
+        if actual != declared[filename]:
+            raise ValueError(f"media hash mismatch: {path}: {actual}")
+    return found
+
+
+def check(source_dirs, manifest, destination, expected_count=550):
+    found = verify_source(source_dirs, manifest, expected_count)
+    if not destination.is_dir() or destination.is_symlink():
+        raise ValueError(f"staging directory is missing or invalid: {destination}")
+    staged = sources((destination,))
+    if staged.keys() != found.keys():
+        missing = sorted(found.keys() - staged.keys())
+        extra = sorted(staged.keys() - found.keys())
+        raise ValueError(f"staged set mismatch; missing={missing}, extra={extra}")
+    for filename, path in staged.items():
+        if digest(path) != digest(found[filename]):
+            raise ValueError(f"staged media differs from source: {filename}")
+    return len(staged)
+
+
+def stage(source_dirs, manifest, destination, expected_count=550):
+    found = verify_source(source_dirs, manifest, expected_count)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent))
+    try:
+        for filename, source in sorted(found.items()):
+            shutil.copyfile(source, temporary / filename)
+        check(source_dirs, manifest, temporary, expected_count)
+        if destination.exists():
+            shutil.rmtree(destination)
+        temporary.replace(destination)
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+    return len(found)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("stage", "check"), nargs="?", default="stage")
+    args = parser.parse_args()
+    count = (
+        stage(SOURCE_DIRS, MANIFEST, DESTINATION)
+        if args.command == "stage"
+        else check(SOURCE_DIRS, MANIFEST, DESTINATION)
+    )
+    print(f"verified {count} flat media files in {DESTINATION}")
+
+
+if __name__ == "__main__":
+    main()

--- a/migration/brainbrew/test_compare_crowdanki.py
+++ b/migration/brainbrew/test_compare_crowdanki.py
@@ -66,6 +66,71 @@ class CompareCrowdAnkiTests(unittest.TestCase):
         self.assertIn("different", result.stdout)
         self.assertIn("Parity: equal", result.stdout)
 
+    def test_top_level_note_order_is_normalized_by_guid(self):
+        candidate = copy.deepcopy(self.deck)
+        candidate["notes"].append(
+            {"guid": "another-guid", "fields": ["Germany", "Berlin"], "tags": ["country", "eu"]}
+        )
+        legacy = copy.deepcopy(candidate)
+        candidate["notes"].reverse()
+        self.write_target("legacy", legacy)
+        self.write_target("candidate", candidate)
+
+        result = self.run_compare()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("semantic JSON sha256 (notes by GUID, media_files by filename)", result.stdout)
+        self.assertIn("Parity: equal", result.stdout)
+
+    def test_media_file_order_is_normalized_by_filename(self):
+        legacy = copy.deepcopy(self.deck)
+        legacy["media_files"].append("map.svg")
+        candidate = copy.deepcopy(legacy)
+        candidate["media_files"].reverse()
+        self.write_target("legacy", legacy)
+        self.write_target("candidate", candidate)
+
+        result = self.run_compare()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("Parity: equal", result.stdout)
+
+    def test_other_list_order_remains_strict(self):
+        cases = [
+            (
+                "fields",
+                lambda deck: deck["notes"][0]["fields"].reverse(),
+                "$.notes[0].fields[0]",
+            ),
+            (
+                "tags",
+                lambda deck: deck["notes"][0]["tags"].reverse(),
+                "$.notes[0].tags[0]",
+            ),
+            (
+                "card templates",
+                lambda deck: deck["note_models"][0]["tmpls"].reverse(),
+                "$.note_models[0].tmpls[0].name",
+            ),
+            (
+                "generic list",
+                lambda deck: deck["deck_configurations"][0]["new"]["delays"].reverse(),
+                "$.deck_configurations[0].new.delays[0]",
+            ),
+        ]
+        for label, mutate, expected_path in cases:
+            with self.subTest(label=label):
+                changed = copy.deepcopy(self.deck)
+                changed["note_models"][0]["tmpls"] = [{"name": "first"}, {"name": "second"}]
+                changed["deck_configurations"][0]["new"]["delays"] = [1, 10]
+                self.write_target("legacy", changed)
+                candidate = copy.deepcopy(changed)
+                mutate(candidate)
+                self.write_target("candidate", candidate)
+                result = self.run_compare()
+                self.assertEqual(result.returncode, 1, result.stdout)
+                self.assertIn(expected_path, result.stdout)
+
     def test_semantic_identity_surfaces_fail_with_paths(self):
         changes = [
             ("guid", lambda deck: deck["notes"][0].update(guid="changed"), "$.notes[0].guid"),
@@ -98,6 +163,11 @@ class CompareCrowdAnkiTests(unittest.TestCase):
 
         self.write_target("duplicate", self.deck, raw='{"media_files":[],"media_files":[]}')
         cases.append(("duplicate key", "legacy", "duplicate", "duplicate JSON key"))
+
+        duplicate_guid = copy.deepcopy(self.deck)
+        duplicate_guid["notes"].append(copy.deepcopy(duplicate_guid["notes"][0]))
+        self.write_target("duplicate-guid", duplicate_guid)
+        cases.append(("duplicate GUID", "legacy", "duplicate-guid", "notes contains duplicate GUIDs"))
 
         self.write_target("no-media", self.deck, media=False)
         cases.append(("media directory", "legacy", "no-media", "media directory is missing"))

--- a/migration/brainbrew/test_stage_media.py
+++ b/migration/brainbrew/test_stage_media.py
@@ -1,0 +1,66 @@
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from migration.brainbrew.stage_media import check, stage
+
+
+class StageMediaTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.flags = self.root / "flags"
+        self.maps = self.root / "maps"
+        self.flags.mkdir()
+        self.maps.mkdir()
+        (self.flags / "flag.svg").write_bytes(b"flag")
+        (self.maps / "map.png").write_bytes(b"map")
+        self.manifest = self.root / "media.yaml"
+        self.destination = self.root / "staged"
+        self.write_manifest(("flag.svg", b"flag"), ("map.png", b"map"))
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def write_manifest(self, *files):
+        self.manifest.write_text(
+            "".join(
+                f"media.{name.replace('.', '-')}:\n"
+                f"  path: {name}\n"
+                f"  sha256: {hashlib.sha256(content).hexdigest()}\n"
+                for name, content in files
+            ),
+            encoding="utf-8",
+        )
+
+    def run_stage(self):
+        return stage((self.flags, self.maps), self.manifest, self.destination, 2)
+
+    def test_stage_and_check(self):
+        self.assertEqual(self.run_stage(), 2)
+        self.assertEqual(check((self.flags, self.maps), self.manifest, self.destination, 2), 2)
+
+    def test_rejects_basename_collision(self):
+        (self.maps / "flag.svg").write_bytes(b"other")
+        with self.assertRaisesRegex(ValueError, "collision"):
+            self.run_stage()
+
+    def test_rejects_missing_or_extra_source(self):
+        (self.maps / "map.png").unlink()
+        with self.assertRaisesRegex(ValueError, "expected 2 source files, found 1"):
+            self.run_stage()
+        (self.maps / "map.png").write_bytes(b"map")
+        (self.maps / "extra.png").write_bytes(b"extra")
+        with self.assertRaisesRegex(ValueError, "expected 2 source files, found 3"):
+            self.run_stage()
+
+    def test_rejects_changed_staged_byte(self):
+        self.run_stage()
+        (self.destination / "map.png").write_bytes(b"changed")
+        with self.assertRaisesRegex(ValueError, "differs from source"):
+            check((self.flags, self.maps), self.manifest, self.destination, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/note-types.yaml
+++ b/note-types.yaml
@@ -1,0 +1,76 @@
+note-type.ultimate-geography:
+  name: '${note-type.name}${variant.name-suffix}'
+  variables:
+    label.capital: Capital
+    label.capital-hint: 'Hint: {{Capital hint}}'
+    label.flag: Flag
+    label.location: Location
+    note-type.name: Ultimate Geography
+    sentence.flag-similar: 'Flag similar to {{Flag similarity}}.'
+    text.direction: ltr
+    variant.name-suffix: ''
+  field_order:
+    - field.country
+    - field.country-info
+    - field.capital
+    - field.capital-info
+    - field.capital-hint
+    - field.flag
+    - field.flag-similarity
+    - field.map
+  fields:
+    field.country:
+      name: Country
+    field.country-info:
+      name: Country info
+    field.capital:
+      name: Capital
+    field.capital-info:
+      name: Capital info
+    field.capital-hint:
+      name: Capital hint
+    field.flag:
+      name: Flag
+    field.flag-similarity:
+      name: Flag similarity
+      message_pattern:
+        kind: list
+        item_format: '{country} ({description})'
+        separator: ', '
+        parameters:
+          country:
+            type: note_field_ref
+            field: field.country
+          description:
+            type: text
+    field.map:
+      name: Map
+  card_template_order:
+    - template.country-capital
+    - template.capital-country
+    - template.flag-country
+    - template.map-country
+  card_templates:
+    template.country-capital:
+      name: Country - Capital
+      question_format: !include 'src/note_models/templates/base/Country - Capital [__LANGUAGE_CODE__].html#question'
+      answer_format: !include 'src/note_models/templates/base/Country - Capital [__LANGUAGE_CODE__].html#answer'
+      adapter_ids: {}
+    template.capital-country:
+      name: Capital - Country
+      question_format: !include 'src/note_models/templates/base/Capital - Country [__LANGUAGE_CODE__].html#question'
+      answer_format: !include 'src/note_models/templates/base/Capital - Country [__LANGUAGE_CODE__].html#answer'
+      adapter_ids: {}
+    template.flag-country:
+      name: Flag - Country
+      question_format: !include 'src/note_models/templates/base/Flag - Country [__LANGUAGE_CODE__].html#question'
+      answer_format: !include 'src/note_models/templates/base/Flag - Country [__LANGUAGE_CODE__].html#answer'
+      adapter_ids: {}
+    template.map-country:
+      name: Map - Country
+      question_format: !include 'src/note_models/templates/base/Map - Country [__LANGUAGE_CODE__].html#question'
+      answer_format: !include 'src/note_models/templates/base/Map - Country [__LANGUAGE_CODE__].html#answer'
+      adapter_ids: {}
+  styling: !include src/note_models/style.css
+  adapter_ids:
+    crowdanki:uuid: 43e2586a-9a65-11e8-a777-a0481cc15658

--- a/src/note_models/templates/base/Capital - Country [__LANGUAGE_CODE__].html
+++ b/src/note_models/templates/base/Capital - Country [__LANGUAGE_CODE__].html
@@ -1,25 +1,25 @@
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 {{#Capital}}
   <div class="value value--top">?</div>
 
   <hr>
 
-  <div class="type">__CAPITAL_TRANSLATION__</div>
+  <div class="type">${label.capital}</div>
   <div class="value">{{Capital}}</div>
-  {{#Capital hint}}<div class="info">__HINT_TRANSLATION__{{Capital hint}}</div>{{/Capital hint}}
+  {{#Capital hint}}<div class="info">${label.capital-hint}</div>{{/Capital hint}}
 {{/Capital}}
 </div>
 
 --
 
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div id=answer class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
 <hr>
 
-<div class="type">__CAPITAL_TRANSLATION__</div>
+<div class="type">${label.capital}</div>
 <div class="value">{{Capital}}</div>
-{{#Capital hint}}<div class="info">__HINT_TRANSLATION__{{Capital hint}}</div>{{/Capital hint}}
+{{#Capital hint}}<div class="info">${label.capital-hint}</div>{{/Capital hint}}
 {{#Capital info}}<div class="info">{{Capital info}}</div>{{/Capital info}}
 </div>

--- a/src/note_models/templates/base/Country - Capital [__LANGUAGE_CODE__].html
+++ b/src/note_models/templates/base/Country - Capital [__LANGUAGE_CODE__].html
@@ -1,24 +1,24 @@
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 {{#Capital}}
   <div class="value value--top">{{Country}}</div>
   {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
   <hr>
 
-  <div class="type">__CAPITAL_TRANSLATION__</div>
+  <div class="type">${label.capital}</div>
   <div class="value">?</div>
 {{/Capital}}
 </div>
 
 --
 
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
 <hr id=answer>
 
-<div class="type">__CAPITAL_TRANSLATION__</div>
+<div class="type">${label.capital}</div>
 <div class="value">{{Capital}}</div>
 {{#Capital info}}<div class="info">{{Capital info}}</div>{{/Capital info}}
 </div>

--- a/src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html
+++ b/src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html
@@ -1,11 +1,11 @@
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 {{#Flag}}
   <div class="value value--top">{{Country}}</div>
   {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
   <hr>
 
-  <div class="type">__FLAG_TRANSLATION__</div>
+  <div class="type">${label.flag}</div>
   <div class="value value--image">
     <svg
       class="placeholder"
@@ -22,13 +22,13 @@
 
 --
 
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
 <hr id=answer>
 
-<div class="type">__FLAG_TRANSLATION__</div>
+<div class="type">${label.flag}</div>
 <div class="value value--image value--back">{{Flag}}</div>
-{{#Flag similarity}}<div class="info">__FLAG_SIMILARITY_TRANSLATION__</div>{{/Flag similarity}}
+{{#Flag similarity}}<div class="info">${sentence.flag-similar}</div>{{/Flag similarity}}
 </div>

--- a/src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__] [Experimental].html
+++ b/src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__] [Experimental].html
@@ -19,11 +19,11 @@
       }
     }));
 </script>
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div class="value value--top">{{Country}}</div>
 <hr>
 
-<div class="type">__LOCATION_TRANSLATION__</div>
+<div class="type">${label.location}</div>
 <div id="map" class="value value--map" style="display: none"></div>
 <div class="value value--image">
   <svg
@@ -48,13 +48,13 @@
 
 --
 
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
 <hr id=answer>
 
-<div class="type">__LOCATION_TRANSLATION__</div>
+<div class="type">${label.location}</div>
 <div id="map" class="value value--map" style="display: none"></div>
 <div class="value value--image">{{Map}}</div>
 </div>

--- a/src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__].html
+++ b/src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__].html
@@ -1,10 +1,10 @@
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 {{#Map}}
   <div class="value value--top">{{Country}}</div>
 
   <hr>
 
-  <div class="type">__LOCATION_TRANSLATION__</div>
+  <div class="type">${label.location}</div>
   <div class="value value--image">
     <svg
       class="placeholder"
@@ -21,12 +21,12 @@
 
 --
 
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
 <hr id=answer>
 
-<div class="type">__LOCATION_TRANSLATION__</div>
+<div class="type">${label.location}</div>
 <div class="value value--image">{{Map}}</div>
 </div>

--- a/src/note_models/templates/base/Flag - Country [__LANGUAGE_CODE__].html
+++ b/src/note_models/templates/base/Flag - Country [__LANGUAGE_CODE__].html
@@ -1,23 +1,23 @@
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 {{#Flag}}
   <div class="value value--top">?</div>
 
   <hr>
 
-  <div class="type">__FLAG_TRANSLATION__</div>
+  <div class="type">${label.flag}</div>
   <div class="value value--image value--front">{{Flag}}</div>
 {{/Flag}}
 </div>
 
 --
 
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div id=answer class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
 <hr>
 
-<div class="type">__FLAG_TRANSLATION__</div>
+<div class="type">${label.flag}</div>
 <div class="value value--image value--back">{{Flag}}</div>
-{{#Flag similarity}}<div class="info">__FLAG_SIMILARITY_TRANSLATION__</div>{{/Flag similarity}}
+{{#Flag similarity}}<div class="info">${sentence.flag-similar}</div>{{/Flag similarity}}
 </div>

--- a/src/note_models/templates/base/Map - Country [__LANGUAGE_CODE__].html
+++ b/src/note_models/templates/base/Map - Country [__LANGUAGE_CODE__].html
@@ -1,22 +1,22 @@
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 {{#Map}}
   <div class="value value--top">?</div>
 
   <hr>
 
-  <div class="type">__LOCATION_TRANSLATION__</div>
+  <div class="type">${label.location}</div>
   <div class="value value--image">{{Map}}</div>
 {{/Map}}
 </div>
 
 --
 
-<div dir="__TEXT_DIRECTION__">
+<div dir="${text.direction}">
 <div id=answer class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
 <hr>
 
-<div class="type">__LOCATION_TRANSLATION__</div>
+<div class="type">${label.location}</div>
 <div class="value value--image">{{Map}}</div>
 </div>

--- a/utils/generate_and_build.py
+++ b/utils/generate_and_build.py
@@ -4,6 +4,16 @@ import subprocess
 from pathlib import Path
 
 
+HTML_TOKENS = {
+    "__CAPITAL_TRANSLATION__": "${label.capital}",
+    "__LOCATION_TRANSLATION__": "${label.location}",
+    "__HINT_TRANSLATION__": "${label.capital-hint}",
+    "__FLAG_TRANSLATION__": "${label.flag}",
+    "__FLAG_SIMILARITY_TRANSLATION__": "${sentence.flag-similar}",
+    "__TEXT_DIRECTION__": "${text.direction}",
+}
+
+
 def validate_subtokens(tokens):
     toks = sorted(tokens, key=len)
     for i, a in enumerate(toks):
@@ -66,7 +76,16 @@ def generate_templates():
 
         for base_path in base_files:
             content = base_path.read_text(encoding="utf-8")
-            rendered = apply_replacements(content, replacements)
+            content_replacements = replacements
+            if base_path.suffix == ".html":
+                content_replacements = [
+                    (
+                        HTML_TOKENS.get(name, name),
+                        value + "{{Capital hint}}" if name == "__HINT_TRANSLATION__" else value,
+                    )
+                    for name, value in replacements
+                ]
+            rendered = apply_replacements(content, content_replacements)
             rendered = apply_replacements(rendered, english_base_case)
 
             output_name = apply_replacements(base_path.name, replacements)


### PR DESCRIPTION
# Shadow English Standard with Rust Brain Brew

**Stack:** 3 of 14  
**Bookmark:** `brainbrew/02-en-standard`  
**Depends on:** `brainbrew/01-identities`

## Summary

- Add the first Rust target: `en-standard`.
- Introduce the root deck, note-type, media, and target manifests.
- Make all seven historical combined templates fragment-ready; wire the four Standard templates through `#question` and `#answer`.
- Leave the legacy Python build runnable.

## Why

English Standard is the smallest end-to-end production slice. It proves the joined CSV source, stable identities, templates, and media model before expanding the matrix.

## Validation

- Pinned Brain Brew `1.0.0-alpha.8` at `1e56a90a42be2522431cd678dfd81617eb4214a6`.
- Passed validate, compose, verify, explain, translations, and CrowdAnki export.
- Matched legacy output at 323 notes and 550 media files.
