### PR TITLE
Add the German and Experimental pilot targets

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -18,17 +18,22 @@ jobs:
         run: |
           pipenv run build
           pipenv run build_experimental
-      - name: Preserve English Standard oracle
+      - name: Preserve pilot oracles
         run: |
-          mkdir -p build/legacy-en-standard-artifact
-          cp -a 'build/Ultimate Geography [EN]/.' build/legacy-en-standard-artifact/
+          mkdir -p build/legacy-pilot
+          cp -a \
+            'build/Ultimate Geography [EN]' \
+            'build/Ultimate Geography [DE]' \
+            'build/Ultimate Geography [EN] [Experimental]' \
+            'build/Ultimate Geography [DE] [Experimental]' \
+            build/legacy-pilot/
       - uses: actions/upload-artifact@v4
         with:
-          name: legacy-en-standard
-          path: build/legacy-en-standard-artifact
+          name: legacy-pilot
+          path: build/legacy-pilot
           if-no-files-found: error
 
-  rust-en-standard-shadow:
+  rust-pilot-shadow:
     needs: legacy
     runs-on: ubuntu-latest
     steps:
@@ -49,9 +54,9 @@ jobs:
           test "$(brainbrew --version)" = 'brainbrew 1.0.0-alpha.8'
       - uses: actions/download-artifact@v4
         with:
-          name: legacy-en-standard
-          path: build/legacy-en-standard
-      - name: Validate English Standard shadow
+          name: legacy-pilot
+          path: build/legacy-pilot
+      - name: Validate four-target pilot
         run: |
           export PYTHONDONTWRITEBYTECODE=1
           python -m unittest -v \
@@ -62,11 +67,9 @@ jobs:
           python migration/brainbrew/stage_media.py stage
           python migration/brainbrew/stage_media.py check
 
-          sha256sum brainbrew.yaml deck.yaml note-types.yaml media.yaml > /tmp/brainbrew-yaml.sha256
-          brainbrew fmt brainbrew.yaml
-          brainbrew fmt deck.yaml
-          brainbrew fmt note-types.yaml
-          brainbrew fmt media.yaml
+          files='brainbrew.yaml deck.yaml note-types.yaml media.yaml experimental.yaml translation-de.yaml overlays/variants/experimental/de.yaml overlays/variants/experimental/en.yaml'
+          sha256sum $files > /tmp/brainbrew-yaml.sha256
+          for file in $files; do brainbrew fmt "$file"; done
           sha256sum --check /tmp/brainbrew-yaml.sha256
 
           brainbrew targets --manifest brainbrew.yaml --json > build/brainbrew-targets.json
@@ -74,22 +77,32 @@ jobs:
           import json
           from pathlib import Path
           targets = json.loads(Path('build/brainbrew-targets.json').read_text())['targets']
-          assert [target['name'] for target in targets] == ['en-standard'], targets
+          assert [target['name'] for target in targets] == [
+              'de-experimental', 'de-standard', 'en-experimental', 'en-standard'
+          ], targets
           PY
 
-          brainbrew validate --manifest brainbrew.yaml --target en-standard
           mkdir -p build/brainbrew
-          brainbrew compose --manifest brainbrew.yaml --target en-standard \
-            --out build/brainbrew/en-standard.yaml
-          brainbrew verify --manifest brainbrew.yaml --target en-standard \
-            --media-root build/brainbrew-media/standard
-          brainbrew explain --manifest brainbrew.yaml --target en-standard --json \
-            > build/brainbrew/en-standard-explain.json
-          brainbrew translations --manifest brainbrew.yaml --target en-standard --json \
-            > build/brainbrew/en-standard-translations.json
-          brainbrew export crowdanki --manifest brainbrew.yaml --target en-standard \
-            --media-root build/brainbrew-media/standard \
-            --out build/brainbrew/crowdanki/en-standard
-          python migration/brainbrew/compare_crowdanki.py \
-            build/legacy-en-standard \
-            build/brainbrew/crowdanki/en-standard
+          for target in de-experimental de-standard en-experimental en-standard; do
+            brainbrew validate --manifest brainbrew.yaml --target "$target"
+            brainbrew compose --manifest brainbrew.yaml --target "$target" \
+              --out "build/brainbrew/$target.yaml"
+            brainbrew verify --manifest brainbrew.yaml --target "$target" \
+              --media-root build/brainbrew-media/standard
+            brainbrew explain --manifest brainbrew.yaml --target "$target" --json \
+              > "build/brainbrew/$target-explain.json"
+            brainbrew translations --manifest brainbrew.yaml --target "$target" --json \
+              > "build/brainbrew/$target-translations.json"
+            brainbrew export crowdanki --manifest brainbrew.yaml --target "$target" \
+              --media-root build/brainbrew-media/standard \
+              --out "build/brainbrew/crowdanki/$target"
+            case "$target" in
+              de-experimental) legacy='Ultimate Geography [DE] [Experimental]' ;;
+              de-standard) legacy='Ultimate Geography [DE]' ;;
+              en-experimental) legacy='Ultimate Geography [EN] [Experimental]' ;;
+              en-standard) legacy='Ultimate Geography [EN]' ;;
+            esac
+            python migration/brainbrew/compare_crowdanki.py \
+              "build/legacy-pilot/$legacy" \
+              "build/brainbrew/crowdanki/$target"
+          done

--- a/brainbrew.yaml
+++ b/brainbrew.yaml
@@ -2,24 +2,65 @@ package:
   id: anki-geo.ultimate-geography
   version: 1.0.0
 base: deck.yaml
-overlays: {}
+overlays:
+  overlay.extension.experimental:
+    file: experimental.yaml
+  overlay.translation.de:
+    file: translation-de.yaml
+  overlay.variant.experimental.de:
+    file: overlays/variants/experimental/de.yaml
+  overlay.variant.experimental.en:
+    file: overlays/variants/experimental/en.yaml
 targets:
+  de-experimental:
+    extends: de-standard
+    overlays:
+      - overlay.extension.experimental
+      - overlay.variant.experimental.de
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/de-experimental
+  de-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.de
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/de-standard
+  en-experimental:
+    extends: en-standard
+    overlays:
+      - overlay.extension.experimental
+      - overlay.variant.experimental.en
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/en-experimental
   en-standard:
     overlays: []
     exports:
       crowdanki:
         out: build/brainbrew/crowdanki/en-standard
 languages:
+  de:
+    display_name: German
+    translation_overlays:
+      base: overlay.translation.de
+    primary_target: standard
+    targets:
+      experimental: de-experimental
+      standard: de-standard
   en:
     display_name: English
     source: true
     primary_target: standard
     targets:
+      experimental: en-experimental
       standard: en-standard
 translation_profile:
   structural_fields:
     - field.flag
     - field.map
+    - field.region-code
   metadata_paths:
     - 'deck.*'
     - 'note_types.*'

--- a/experimental.yaml
+++ b/experimental.yaml
@@ -1,0 +1,67 @@
+id: overlay.extension.experimental
+kind: extension
+field_additions:
+  note-type.ultimate-geography:
+    fields:
+      field.region-code: Region code
+    values:
+      from_csv:
+        - descriptor: src/data/experimental-region.yaml
+          parameters: {}
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    variables:
+      variant.name-suffix:
+        intent: replace
+        value: ' [Experimental]'
+        expected_base:
+          value: ''
+    styling:
+      intent: replace
+      value: !include 'src/note_models/style_[Experimental].css'
+      expected_base:
+        value: !include src/note_models/style.css
+    card_templates:
+      template.country-flag:
+        intent: add
+        insert_after: template.capital-country
+        template:
+          name: Country - Flag
+          question_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#question'
+          answer_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#answer'
+          adapter_ids: {}
+      template.country-map:
+        intent: add
+        insert_after: template.flag-country
+        template:
+          name: Country - Map
+          question_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__] [Experimental].html#question'
+          answer_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__] [Experimental].html#answer'
+          adapter_ids: {}
+media:
+  media.interactive-map-config-js:
+    intent: add
+    path: _ug-interactive_map_config.js
+    source: src/media/experimental_assets/_ug-interactive_map_config.js
+    sha256: a6c8862ea95a0257f951ef4fdc9a3c1a7aa069d4bbc04847d064b26bf4885ea0
+  media.interactive-map-init-js:
+    intent: add
+    path: _ug-interactive_map_init.js
+    source: src/media/experimental_assets/_ug-interactive_map_init.js
+    sha256: fa70e8fa2a501f1360a83652157befa28b1de8a20a9a660f35e520d3c19c6ad2
+  media.jsvectormap-css:
+    intent: add
+    path: _ug-jsvectormap.min.css
+    source: src/media/experimental_assets/_ug-jsvectormap.min.css
+    sha256: fae18b26699328ea81afed84e8a0d8b3f351b07c5290e35714750bd1fcb63bfe
+  media.jsvectormap-js:
+    intent: add
+    path: _ug-jsvectormap.js
+    source: src/media/experimental_assets/_ug-jsvectormap.js
+    sha256: e3979d3e3dc42d5de35167faaac2722de730187a909ca4a98b058e8ed6b18f7b
+  media.world-js:
+    intent: add
+    path: _ug-world.js
+    source: src/media/experimental_assets/_ug-world.js
+    sha256: ae54701d4796a334c7f2168aab07d631c09c0ff6f84d6813744a3cb6c27008c1

--- a/overlays/variants/experimental/de.yaml
+++ b/overlays/variants/experimental/de.yaml
@@ -1,0 +1,11 @@
+id: overlay.variant.experimental.de
+kind: extension
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    adapter_ids:
+      crowdanki:uuid:
+        intent: override
+        value: 98c67202-2209-48c1-b3de-475fa58372af
+        expected_base:
+          value: cb3de16f-7c9c-4944-994a-e17ec2018c28

--- a/overlays/variants/experimental/en.yaml
+++ b/overlays/variants/experimental/en.yaml
@@ -1,0 +1,11 @@
+id: overlay.variant.experimental.en
+kind: extension
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    adapter_ids:
+      crowdanki:uuid:
+        intent: override
+        value: 2e98b530-7583-5551-1fd7-51e6969d58ed
+        expected_base:
+          value: 43e2586a-9a65-11e8-a777-a0481cc15658

--- a/translation-de.yaml
+++ b/translation-de.yaml
@@ -1,0 +1,27 @@
+id: overlay.translation.de
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: de
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Hauptstadt
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Hinweis: {{Capital hint}}'
+    label.flag:
+      Flag: Flagge
+    label.location:
+      Location: Lage
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [DE]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Flagge ähnlich wie {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: cb3de16f-7c9c-4944-994a-e17ec2018c28


### PR DESCRIPTION
# Add the German and Experimental pilot targets

**Stack:** 4 of 14  
**Bookmark:** `brainbrew/03-pilot`  
**Depends on:** `brainbrew/02-en-standard`

## Summary

- Add `de-standard`, `en-experimental`, and `de-experimental`.
- Introduce shared Experimental structure without localizing every language yet.
- Package the five Experimental JavaScript/CSS assets with authored SHA-256 values.

## Why

This pilot exercises both localization and the structurally different Experimental deck before broad rollout. Package-owned assets avoid a second staged media tree.

## Validation

- All four adopted targets match legacy semantics and media bytes.
- Standard targets contain 550 media files; Experimental targets contain 555.
- `brainbrew media hash --all-targets` reports zero source changes.
- Experimental assets remain absent from Standard exports.
