### PR TITLE
Add English Extended

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -18,22 +18,23 @@ jobs:
         run: |
           pipenv run build
           pipenv run build_experimental
-      - name: Preserve pilot oracles
+      - name: Preserve adopted-target oracles
         run: |
-          mkdir -p build/legacy-pilot
+          mkdir -p build/legacy-adopted
           cp -a \
             'build/Ultimate Geography [EN]' \
             'build/Ultimate Geography [DE]' \
             'build/Ultimate Geography [EN] [Experimental]' \
             'build/Ultimate Geography [DE] [Experimental]' \
-            build/legacy-pilot/
+            'build/Ultimate Geography [EN] [Extended]' \
+            build/legacy-adopted/
       - uses: actions/upload-artifact@v4
         with:
-          name: legacy-pilot
-          path: build/legacy-pilot
+          name: legacy-adopted
+          path: build/legacy-adopted
           if-no-files-found: error
 
-  rust-pilot-shadow:
+  rust-shadow:
     needs: legacy
     runs-on: ubuntu-latest
     steps:
@@ -54,9 +55,9 @@ jobs:
           test "$(brainbrew --version)" = 'brainbrew 1.0.0-alpha.8'
       - uses: actions/download-artifact@v4
         with:
-          name: legacy-pilot
-          path: build/legacy-pilot
-      - name: Validate four-target pilot
+          name: legacy-adopted
+          path: build/legacy-adopted
+      - name: Validate adopted Rust targets
         run: |
           export PYTHONDONTWRITEBYTECODE=1
           python -m unittest -v \
@@ -67,7 +68,7 @@ jobs:
           python migration/brainbrew/stage_media.py stage
           python migration/brainbrew/stage_media.py check
 
-          files='brainbrew.yaml deck.yaml note-types.yaml media.yaml experimental.yaml translation-de.yaml overlays/variants/experimental/de.yaml overlays/variants/experimental/en.yaml'
+          files='brainbrew.yaml deck.yaml note-types.yaml media.yaml experimental.yaml extended.yaml translation-de.yaml overlays/variants/experimental/de.yaml overlays/variants/experimental/en.yaml overlays/variants/extended/en.yaml'
           sha256sum $files > /tmp/brainbrew-yaml.sha256
           for file in $files; do brainbrew fmt "$file"; done
           sha256sum --check /tmp/brainbrew-yaml.sha256
@@ -78,12 +79,12 @@ jobs:
           from pathlib import Path
           targets = json.loads(Path('build/brainbrew-targets.json').read_text())['targets']
           assert [target['name'] for target in targets] == [
-              'de-experimental', 'de-standard', 'en-experimental', 'en-standard'
+              'de-experimental', 'de-standard', 'en-experimental', 'en-extended', 'en-standard'
           ], targets
           PY
 
           mkdir -p build/brainbrew
-          for target in de-experimental de-standard en-experimental en-standard; do
+          for target in de-experimental de-standard en-experimental en-extended en-standard; do
             brainbrew validate --manifest brainbrew.yaml --target "$target"
             brainbrew compose --manifest brainbrew.yaml --target "$target" \
               --out "build/brainbrew/$target.yaml"
@@ -100,9 +101,10 @@ jobs:
               de-experimental) legacy='Ultimate Geography [DE] [Experimental]' ;;
               de-standard) legacy='Ultimate Geography [DE]' ;;
               en-experimental) legacy='Ultimate Geography [EN] [Experimental]' ;;
+              en-extended) legacy='Ultimate Geography [EN] [Extended]' ;;
               en-standard) legacy='Ultimate Geography [EN]' ;;
             esac
             python migration/brainbrew/compare_crowdanki.py \
-              "build/legacy-pilot/$legacy" \
+              "build/legacy-adopted/$legacy" \
               "build/brainbrew/crowdanki/$target"
           done

--- a/brainbrew.yaml
+++ b/brainbrew.yaml
@@ -5,12 +5,16 @@ base: deck.yaml
 overlays:
   overlay.extension.experimental:
     file: experimental.yaml
+  overlay.extension.extended:
+    file: extended.yaml
   overlay.translation.de:
     file: translation-de.yaml
   overlay.variant.experimental.de:
     file: overlays/variants/experimental/de.yaml
   overlay.variant.experimental.en:
     file: overlays/variants/experimental/en.yaml
+  overlay.variant.extended.en:
+    file: overlays/variants/extended/en.yaml
 targets:
   de-experimental:
     extends: de-standard
@@ -35,6 +39,14 @@ targets:
     exports:
       crowdanki:
         out: build/brainbrew/crowdanki/en-experimental
+  en-extended:
+    extends: en-standard
+    overlays:
+      - overlay.extension.extended
+      - overlay.variant.extended.en
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/en-extended
   en-standard:
     overlays: []
     exports:
@@ -55,6 +67,7 @@ languages:
     primary_target: standard
     targets:
       experimental: en-experimental
+      extended: en-extended
       standard: en-standard
 translation_profile:
   structural_fields:

--- a/extended.yaml
+++ b/extended.yaml
@@ -1,0 +1,28 @@
+id: overlay.extension.extended
+kind: extension
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    variables:
+      variant.name-suffix:
+        intent: replace
+        value: ' [Extended]'
+        expected_base:
+          value: ''
+    card_templates:
+      template.country-flag:
+        intent: add
+        insert_after: template.capital-country
+        template:
+          name: Country - Flag
+          question_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#question'
+          answer_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#answer'
+          adapter_ids: {}
+      template.country-map:
+        intent: add
+        insert_after: template.flag-country
+        template:
+          name: Country - Map
+          question_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__].html#question'
+          answer_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__].html#answer'
+          adapter_ids: {}

--- a/overlays/variants/extended/en.yaml
+++ b/overlays/variants/extended/en.yaml
@@ -1,0 +1,11 @@
+id: overlay.variant.extended.en
+kind: extension
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    adapter_ids:
+      crowdanki:uuid:
+        intent: override
+        value: 0a39f994-daaf-11e8-b984-a0481cc15658
+        expected_base:
+          value: 43e2586a-9a65-11e8-a777-a0481cc15658


### PR DESCRIPTION
# Add English Extended

**Stack:** 5 of 14  
**Bookmark:** `brainbrew/04-en-extended`  
**Depends on:** `brainbrew/03-pilot`

## Summary

- Add `en-extended` as the first Extended target.
- Introduce one language-neutral Extended structural overlay.
- Keep English-specific adapter metadata in a small localized overlay.

## Why

Extended is a separate structural variant, but its structure should not be duplicated per language. This commit proves the shared overlay before adding the localized family.

## Validation

- Passed the full alpha.8 command surface.
- Matched legacy at 323 notes, six templates, and 550 media files.
- Confirmed no Experimental assets leak into Extended.
