### PR TITLE
Add the remaining LTR Standard targets

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -18,20 +18,14 @@ jobs:
         run: |
           pipenv run build
           pipenv run build_experimental
-      - name: Preserve adopted-target oracles
+      - name: Preserve legacy oracles
         run: |
-          mkdir -p build/legacy-adopted
-          cp -a \
-            'build/Ultimate Geography [EN]' \
-            'build/Ultimate Geography [DE]' \
-            'build/Ultimate Geography [EN] [Experimental]' \
-            'build/Ultimate Geography [DE] [Experimental]' \
-            'build/Ultimate Geography [EN] [Extended]' \
-            build/legacy-adopted/
+          mkdir -p build/legacy-all
+          cp -a build/'Ultimate Geography '* build/legacy-all/
       - uses: actions/upload-artifact@v4
         with:
-          name: legacy-adopted
-          path: build/legacy-adopted
+          name: legacy-all
+          path: build/legacy-all
           if-no-files-found: error
 
   rust-shadow:
@@ -55,8 +49,8 @@ jobs:
           test "$(brainbrew --version)" = 'brainbrew 1.0.0-alpha.8'
       - uses: actions/download-artifact@v4
         with:
-          name: legacy-adopted
-          path: build/legacy-adopted
+          name: legacy-all
+          path: build/legacy-all
       - name: Validate adopted Rust targets
         run: |
           export PYTHONDONTWRITEBYTECODE=1
@@ -68,23 +62,25 @@ jobs:
           python migration/brainbrew/stage_media.py stage
           python migration/brainbrew/stage_media.py check
 
-          files='brainbrew.yaml deck.yaml note-types.yaml media.yaml experimental.yaml extended.yaml translation-de.yaml overlays/variants/experimental/de.yaml overlays/variants/experimental/en.yaml overlays/variants/extended/en.yaml'
-          sha256sum $files > /tmp/brainbrew-yaml.sha256
-          for file in $files; do brainbrew fmt "$file"; done
+          files=(brainbrew.yaml deck.yaml note-types.yaml media.yaml experimental.yaml extended.yaml)
+          for file in translation-*.yaml overlays/variants/*/*.yaml; do
+            test ! -e "$file" || files+=("$file")
+          done
+          sha256sum "${files[@]}" > /tmp/brainbrew-yaml.sha256
+          for file in "${files[@]}"; do brainbrew fmt "$file"; done
           sha256sum --check /tmp/brainbrew-yaml.sha256
 
           brainbrew targets --manifest brainbrew.yaml --json > build/brainbrew-targets.json
-          python - <<'PY'
+          python - <<'PY' > build/brainbrew-target-names
           import json
           from pathlib import Path
-          targets = json.loads(Path('build/brainbrew-targets.json').read_text())['targets']
-          assert [target['name'] for target in targets] == [
-              'de-experimental', 'de-standard', 'en-experimental', 'en-extended', 'en-standard'
-          ], targets
+          for target in json.loads(Path('build/brainbrew-targets.json').read_text())['targets']:
+              print(target['name'])
           PY
+          diff -u migration/brainbrew/expected-targets.txt build/brainbrew-target-names
 
-          mkdir -p build/brainbrew
-          for target in de-experimental de-standard en-experimental en-extended en-standard; do
+          mkdir -p build/brainbrew/crowdanki
+          while IFS= read -r target; do
             brainbrew validate --manifest brainbrew.yaml --target "$target"
             brainbrew compose --manifest brainbrew.yaml --target "$target" \
               --out "build/brainbrew/$target.yaml"
@@ -97,14 +93,18 @@ jobs:
             brainbrew export crowdanki --manifest brainbrew.yaml --target "$target" \
               --media-root build/brainbrew-media/standard \
               --out "build/brainbrew/crowdanki/$target"
-            case "$target" in
-              de-experimental) legacy='Ultimate Geography [DE] [Experimental]' ;;
-              de-standard) legacy='Ultimate Geography [DE]' ;;
-              en-experimental) legacy='Ultimate Geography [EN] [Experimental]' ;;
-              en-extended) legacy='Ultimate Geography [EN] [Extended]' ;;
-              en-standard) legacy='Ultimate Geography [EN]' ;;
+
+            language=${target%-*}
+            variant=${target##*-}
+            language=$(printf '%s' "$language" | tr '[:lower:]' '[:upper:]')
+            legacy="Ultimate Geography [$language]"
+            case "$variant" in
+              experimental) legacy="$legacy [Experimental]" ;;
+              extended) legacy="$legacy [Extended]" ;;
+              standard) ;;
+              *) echo "Unknown target variant: $variant" >&2; exit 1 ;;
             esac
             python migration/brainbrew/compare_crowdanki.py \
-              "build/legacy-adopted/$legacy" \
+              "build/legacy-all/$legacy" \
               "build/brainbrew/crowdanki/$target"
-          done
+          done < build/brainbrew-target-names

--- a/brainbrew.yaml
+++ b/brainbrew.yaml
@@ -7,8 +7,30 @@ overlays:
     file: experimental.yaml
   overlay.extension.extended:
     file: extended.yaml
+  overlay.translation.cs:
+    file: translation-cs.yaml
+  overlay.translation.da:
+    file: translation-da.yaml
   overlay.translation.de:
     file: translation-de.yaml
+  overlay.translation.es:
+    file: translation-es.yaml
+  overlay.translation.fr:
+    file: translation-fr.yaml
+  overlay.translation.it:
+    file: translation-it.yaml
+  overlay.translation.nb:
+    file: translation-nb.yaml
+  overlay.translation.nl:
+    file: translation-nl.yaml
+  overlay.translation.pl:
+    file: translation-pl.yaml
+  overlay.translation.pt:
+    file: translation-pt.yaml
+  overlay.translation.ru:
+    file: translation-ru.yaml
+  overlay.translation.sv:
+    file: translation-sv.yaml
   overlay.variant.experimental.de:
     file: overlays/variants/experimental/de.yaml
   overlay.variant.experimental.en:
@@ -16,6 +38,20 @@ overlays:
   overlay.variant.extended.en:
     file: overlays/variants/extended/en.yaml
 targets:
+  cs-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.cs
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/cs-standard
+  da-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.da
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/da-standard
   de-experimental:
     extends: de-standard
     overlays:
@@ -52,7 +88,84 @@ targets:
     exports:
       crowdanki:
         out: build/brainbrew/crowdanki/en-standard
+  es-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.es
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/es-standard
+  fr-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.fr
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/fr-standard
+  it-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.it
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/it-standard
+  nb-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.nb
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/nb-standard
+  nl-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.nl
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/nl-standard
+  pl-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.pl
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/pl-standard
+  pt-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.pt
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/pt-standard
+  ru-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.ru
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/ru-standard
+  sv-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.sv
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/sv-standard
 languages:
+  cs:
+    display_name: Czech
+    translation_overlays:
+      base: overlay.translation.cs
+    primary_target: standard
+    targets:
+      standard: cs-standard
+  da:
+    display_name: Danish
+    translation_overlays:
+      base: overlay.translation.da
+    primary_target: standard
+    targets:
+      standard: da-standard
   de:
     display_name: German
     translation_overlays:
@@ -69,6 +182,69 @@ languages:
       experimental: en-experimental
       extended: en-extended
       standard: en-standard
+  es:
+    display_name: Spanish
+    translation_overlays:
+      base: overlay.translation.es
+    primary_target: standard
+    targets:
+      standard: es-standard
+  fr:
+    display_name: French
+    translation_overlays:
+      base: overlay.translation.fr
+    primary_target: standard
+    targets:
+      standard: fr-standard
+  it:
+    display_name: Italian
+    translation_overlays:
+      base: overlay.translation.it
+    primary_target: standard
+    targets:
+      standard: it-standard
+  nb:
+    display_name: 'Norwegian Bokmål'
+    translation_overlays:
+      base: overlay.translation.nb
+    primary_target: standard
+    targets:
+      standard: nb-standard
+  nl:
+    display_name: Dutch
+    translation_overlays:
+      base: overlay.translation.nl
+    primary_target: standard
+    targets:
+      standard: nl-standard
+  pl:
+    display_name: Polish
+    translation_overlays:
+      base: overlay.translation.pl
+    primary_target: standard
+    targets:
+      standard: pl-standard
+  pt:
+    display_name: Portuguese
+    translation_overlays:
+      base: overlay.translation.pt
+    primary_target: standard
+    targets:
+      standard: pt-standard
+  ru:
+    display_name: Russian
+    translation_overlays:
+      base: overlay.translation.ru
+    primary_target: standard
+    targets:
+      standard: ru-standard
+  sv:
+    display_name: Swedish
+    translation_overlays:
+      base: overlay.translation.sv
+    primary_target: standard
+    targets:
+      standard: sv-standard
 translation_profile:
   structural_fields:
     - field.flag

--- a/migration/brainbrew/expected-targets.txt
+++ b/migration/brainbrew/expected-targets.txt
@@ -1,0 +1,16 @@
+cs-standard
+da-standard
+de-experimental
+de-standard
+en-experimental
+en-extended
+en-standard
+es-standard
+fr-standard
+it-standard
+nb-standard
+nl-standard
+pl-standard
+pt-standard
+ru-standard
+sv-standard

--- a/translation-cs.yaml
+++ b/translation-cs.yaml
@@ -1,0 +1,27 @@
+id: overlay.translation.cs
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: cs
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: 'Hlavní město'
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Náznak: {{Capital hint}}'
+    label.flag:
+      Flag: Vlajka
+    label.location:
+      Location: Poloha
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [CS]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Vlajka podobná jako {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: 47d13c81-b471-4471-8e87-ebad53fa7307

--- a/translation-da.yaml
+++ b/translation-da.yaml
@@ -1,0 +1,25 @@
+id: overlay.translation.da
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: da
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Hovedstad
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Ledetråd: {{Capital hint}}'
+    label.location:
+      Location: Placering
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [DA]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Flaget ligner {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: 15daaec7-4097-4d97-ba94-9db44f8b8f51

--- a/translation-es.yaml
+++ b/translation-es.yaml
@@ -1,0 +1,37 @@
+id: overlay.translation.es
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: es
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Pista: {{Capital hint}}'
+    label.flag:
+      Flag: Bandera
+    label.location:
+      Location: 'Ubicación'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [ES]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Bandera similar a {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43c5ba66-9a65-11e8-90c9-a0481cc15658: cb4d32ee-12ed-9960-1841-28c09449ded0
+      43e2586a-9a65-11e8-a777-a0481cc15658: 0bacddfd-1e81-4e62-9152-bdff33db0374
+deck:
+  name:
+    intent: replace
+    value: 'Ultimate Geography [ES]'
+    expected_base:
+      value: Ultimate Geography
+  description:
+    intent: replace
+    value: !include src/headers/desc_es.html
+    expected_base:
+      value: !include src/headers/desc.html

--- a/translation-fr.yaml
+++ b/translation-fr.yaml
@@ -1,0 +1,27 @@
+id: overlay.translation.fr
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: fr
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Capitale
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Indice : {{Capital hint}}'
+    label.flag:
+      Flag: Drapeau
+    label.location:
+      Location: Emplacement
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [FR]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Drapeau similaire à : {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: fd72d808-58d4-43ea-97db-24196747f24c

--- a/translation-it.yaml
+++ b/translation-it.yaml
@@ -1,0 +1,27 @@
+id: overlay.translation.it
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: it
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Capitale
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Suggerimento: {{Capital hint}}'
+    label.flag:
+      Flag: Bandiera
+    label.location:
+      Location: Posizione
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [IT]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Bandiera simile a: {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: cd65a274-7341-4e72-8de5-5d3d83ea4537

--- a/translation-nb.yaml
+++ b/translation-nb.yaml
@@ -1,0 +1,25 @@
+id: overlay.translation.nb
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: nb
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Hovedstad
+    label.flag:
+      Flag: Flagg
+    label.location:
+      Location: Beliggenhet
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [NB]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Flagg som ligner på {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: 8ccdc1f6-b042-4d55-8fcd-9e08b5b71dc7

--- a/translation-nl.yaml
+++ b/translation-nl.yaml
@@ -1,0 +1,27 @@
+id: overlay.translation.nl
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: nl
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Hoofdstad
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Aanwijzing: {{Capital hint}}'
+    label.flag:
+      Flag: Vlag
+    label.location:
+      Location: Ligging
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [NL]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Vlag vergelijkbaar met {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: 8263244e-6f5e-457a-bb65-a836a6c058a3

--- a/translation-pl.yaml
+++ b/translation-pl.yaml
@@ -1,0 +1,27 @@
+id: overlay.translation.pl
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: pl
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Stolica
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Wskazówka: {{Capital hint}}'
+    label.flag:
+      Flag: Flaga
+    label.location:
+      Location: 'Położenie'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [PL]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Podobne flagi: {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: 84786477-e28a-490e-958d-7b35946d7b11

--- a/translation-pt.yaml
+++ b/translation-pt.yaml
@@ -1,0 +1,25 @@
+id: overlay.translation.pt
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: pt
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Dica: {{Capital hint}}'
+    label.flag:
+      Flag: Bandeira
+    label.location:
+      Location: 'Localização'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [PT]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Bandeira parecida com: {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: 3da2a851-258c-447f-9d16-91a663663675

--- a/translation-ru.yaml
+++ b/translation-ru.yaml
@@ -1,0 +1,27 @@
+id: overlay.translation.ru
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: ru
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: 'Столица'
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Подсказка: {{Capital hint}}'
+    label.flag:
+      Flag: 'Флаг'
+    label.location:
+      Location: 'Местоположение'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [RU]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Похожие флаги: {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43e2586a-9a65-11e8-a777-a0481cc15658: 2aa62e36-601e-4e4c-a124-5a79b14f8697

--- a/translation-sv.yaml
+++ b/translation-sv.yaml
@@ -1,0 +1,39 @@
+id: overlay.translation.sv
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: sv
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: Huvudstad
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'Ledtråd: {{Capital hint}}'
+    label.flag:
+      Flag: Flagga
+    label.location:
+      Location: 'Läge'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [SV]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'Flaggan liknar {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43c5ba66-9a65-11e8-90c9-a0481cc15658: 75bfcdb5-0ff3-4038-83cb-3e6ed974f439
+      43e2586a-9a65-11e8-a777-a0481cc15658: 3090ce89-5fd8-4107-86df-3e7a74ec288f
+deck:
+  name:
+    intent: replace
+    value: 'Ultimate Geography [SV]'
+    expected_base:
+      value: Ultimate Geography
+  description:
+    intent: replace
+    value: !include src/headers/desc_sv.html
+    expected_base:
+      value: !include src/headers/desc.html


### PR DESCRIPTION
# Add the remaining LTR Standard targets

**Stack:** 6 of 14  
**Bookmark:** `brainbrew/05-standard-ltr`  
**Depends on:** `brainbrew/04-en-extended`

## Summary

- Add Czech, Danish, Spanish, French, Italian, Norwegian Bokmål, Dutch, Polish, Portuguese, Russian, and Swedish Standard.
- Preserve literal localized CSV parameters and adapter identities.
- Add `brainbrew-targets` inventory gating during the migration.
- Preserve the known Swedish source anomalies rather than hiding editorial changes here.

## Why

This expands the proven Standard model across all remaining left-to-right languages while keeping localization residue explicit and reviewable.

## Validation

- Each new target passes validate, compose, verify, explain, translations, and export.
- Each matches legacy at 323 notes and 550 media files.
- All 48 legacy targets continue to rebuild unchanged.
