### PR TITLE
Add CJK and RTL Standard targets

### DIFF
--- a/brainbrew.yaml
+++ b/brainbrew.yaml
@@ -17,6 +17,8 @@ overlays:
     file: translation-es.yaml
   overlay.translation.fr:
     file: translation-fr.yaml
+  overlay.translation.he:
+    file: translation-he.yaml
   overlay.translation.it:
     file: translation-it.yaml
   overlay.translation.nb:
@@ -31,6 +33,10 @@ overlays:
     file: translation-ru.yaml
   overlay.translation.sv:
     file: translation-sv.yaml
+  overlay.translation.zh:
+    file: translation-zh.yaml
+  overlay.translation.zh-tw:
+    file: translation-zh-tw.yaml
   overlay.variant.experimental.de:
     file: overlays/variants/experimental/de.yaml
   overlay.variant.experimental.en:
@@ -102,6 +108,13 @@ targets:
     exports:
       crowdanki:
         out: build/brainbrew/crowdanki/fr-standard
+  he-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.he
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/he-standard
   it-standard:
     extends: en-standard
     overlays:
@@ -151,6 +164,20 @@ targets:
     exports:
       crowdanki:
         out: build/brainbrew/crowdanki/sv-standard
+  zh-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.zh
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/zh-standard
+  zh-tw-standard:
+    extends: en-standard
+    overlays:
+      - overlay.translation.zh-tw
+    exports:
+      crowdanki:
+        out: build/brainbrew/crowdanki/zh-tw-standard
 languages:
   cs:
     display_name: Czech
@@ -196,6 +223,13 @@ languages:
     primary_target: standard
     targets:
       standard: fr-standard
+  he:
+    display_name: Hebrew
+    translation_overlays:
+      base: overlay.translation.he
+    primary_target: standard
+    targets:
+      standard: he-standard
   it:
     display_name: Italian
     translation_overlays:
@@ -245,6 +279,20 @@ languages:
     primary_target: standard
     targets:
       standard: sv-standard
+  zh:
+    display_name: 'Chinese (Simplified)'
+    translation_overlays:
+      base: overlay.translation.zh
+    primary_target: standard
+    targets:
+      standard: zh-standard
+  zh-tw:
+    display_name: 'Chinese (Traditional)'
+    translation_overlays:
+      base: overlay.translation.zh-tw
+    primary_target: standard
+    targets:
+      standard: zh-tw-standard
 translation_profile:
   structural_fields:
     - field.flag

--- a/migration/brainbrew/expected-targets.txt
+++ b/migration/brainbrew/expected-targets.txt
@@ -7,6 +7,7 @@ en-extended
 en-standard
 es-standard
 fr-standard
+he-standard
 it-standard
 nb-standard
 nl-standard
@@ -14,3 +15,5 @@ pl-standard
 pt-standard
 ru-standard
 sv-standard
+zh-standard
+zh-tw-standard

--- a/translation-he.yaml
+++ b/translation-he.yaml
@@ -1,0 +1,95 @@
+id: overlay.translation.he
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: he
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: 'בירה'
+    label.capital-hint:
+      'Hint: {{Capital hint}}': 'רמז: {{Capital hint}}'
+    label.flag:
+      Flag: 'דגל'
+    label.location:
+      Location: 'מיקום'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [HE]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': 'דגל דומה: {{Flag similarity}}.'
+  adapter_ids:
+    crowdanki:uuid:
+      43c5ba66-9a65-11e8-90c9-a0481cc15658: 35307c16-cdbf-4c06-b3e3-61a654abc1c6
+      43e2586a-9a65-11e8-a777-a0481cc15658: f37b2a2a-e97a-4909-8b56-f84c9caa5348
+deck:
+  name:
+    intent: replace
+    value: 'Ultimate Geography [HE]'
+    expected_base:
+      value: Ultimate Geography
+  description:
+    intent: replace
+    value: !include src/headers/desc_he.html
+    expected_base:
+      value: !include src/headers/desc.html
+note_types:
+  note-type.ultimate-geography:
+    intent: merge
+    variables:
+      text.direction:
+        intent: replace
+        value: rtl
+        expected_base:
+          value: ltr
+    fields:
+      field.capital:
+        intent: override
+        name: Capital
+        rtl: true
+        expected_base:
+          fingerprint: sha256:v2:a88a704e28a3164986659ec6f45998e73d0cc582e8048e8fcc1274349a91446a
+      field.capital-hint:
+        intent: override
+        name: Capital hint
+        rtl: true
+        expected_base:
+          fingerprint: sha256:v2:df994f573fdf0ad6290e24941b5bcfa8dba49048df0cd081d0503ee77bf1ef41
+      field.capital-info:
+        intent: override
+        name: Capital info
+        rtl: true
+        expected_base:
+          fingerprint: sha256:v2:609fc8e482031015a6c96874bfc52d0e0b7036076be1f7edd0137278465e3538
+      field.country:
+        intent: override
+        name: Country
+        rtl: true
+        expected_base:
+          fingerprint: sha256:v2:4dbf4483b9c72b81d7cf479d97a202921351936f939ee8a4d484d4a0b5b24f27
+      field.country-info:
+        intent: override
+        name: Country info
+        rtl: true
+        expected_base:
+          fingerprint: sha256:v2:d3e826358c4b78479f435577fee9ae57e3f4559d96a3ffa76d6b4052f1e95cda
+      field.flag-similarity:
+        intent: override
+        name: Flag similarity
+        rtl: true
+        message_pattern:
+          kind: list
+          item_format: '{country} ({description})'
+          separator: ', '
+          parameters:
+            country:
+              type: note_field_ref
+              field: field.country
+            description:
+              type: text
+        expected_base:
+          fingerprint: sha256:v2:917df99572ff087cf2163be8623f26048ded5f843b8cded33fa708ca6e6b3d06

--- a/translation-zh-tw.yaml
+++ b/translation-zh-tw.yaml
@@ -1,0 +1,39 @@
+id: overlay.translation.zh-tw
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: zh-tw
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: '首都'
+    label.capital-hint:
+      'Hint: {{Capital hint}}': '提示：{{Capital hint}}'
+    label.flag:
+      Flag: '旗幟'
+    label.location:
+      Location: '位置'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [ZH-TW]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': '旗幟類似於：{{Flag similarity}}。'
+  adapter_ids:
+    crowdanki:uuid:
+      43c5ba66-9a65-11e8-90c9-a0481cc15658: 3d365148-83a7-4b53-8dbc-e3b183524025
+      43e2586a-9a65-11e8-a777-a0481cc15658: d75ad494-71f3-4909-beda-b80ec04c7a0d
+deck:
+  name:
+    intent: replace
+    value: 'Ultimate Geography [ZH-TW]'
+    expected_base:
+      value: Ultimate Geography
+  description:
+    intent: replace
+    value: !include src/headers/desc_zh-tw.html
+    expected_base:
+      value: !include src/headers/desc.html

--- a/translation-zh.yaml
+++ b/translation-zh.yaml
@@ -1,0 +1,39 @@
+id: overlay.translation.zh
+kind: translation
+translations:
+  from_csv:
+    - descriptor: src/data/ultimate-geography.yaml
+      parameters:
+        language: zh
+      exclude:
+        source_texts: []
+        note_ids: []
+        paths: []
+  variables:
+    label.capital:
+      Capital: '首都'
+    label.capital-hint:
+      'Hint: {{Capital hint}}': '提示：{{Capital hint}}'
+    label.flag:
+      Flag: '旗帜'
+    label.location:
+      Location: '位置'
+    note-type.name:
+      Ultimate Geography: 'Ultimate Geography [ZH]'
+    sentence.flag-similar:
+      'Flag similar to {{Flag similarity}}.': '旗帜类似于：{{Flag similarity}}。'
+  adapter_ids:
+    crowdanki:uuid:
+      43c5ba66-9a65-11e8-90c9-a0481cc15658: 6c995ee1-4b62-4019-a033-de0ef8651c83
+      43e2586a-9a65-11e8-a777-a0481cc15658: 30c7ff39-56b5-4693-8e16-aa862eb7a619
+deck:
+  name:
+    intent: replace
+    value: 'Ultimate Geography [ZH]'
+    expected_base:
+      value: Ultimate Geography
+  description:
+    intent: replace
+    value: !include src/headers/desc_zh.html
+    expected_base:
+      value: !include src/headers/desc.html


### PR DESCRIPTION
# Add CJK and RTL Standard targets

**Stack:** 7 of 14  
**Bookmark:** `brainbrew/06-standard-cjk-rtl`  
**Depends on:** `brainbrew/05-standard-ltr`

## Summary

- Add Hebrew, Chinese, and Traditional Chinese Standard.
- Preserve localized template direction and literal CSV selections.
- Preserve canonical Hebrew field-level RTL metadata.

## Why

CJK and RTL behavior are the remaining Standard edge cases. Isolating them makes directionality and field metadata easy to inspect before adding more variants.

## Validation

- All three targets match legacy at 323 notes and 550 media files.
- Hebrew Standard exports the RTL vector `[true, true, true, true, true, false, true, false]`.
- The Standard family is complete at 16 targets.
