### PR TITLE
Certify full dual-pipeline parity

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -51,10 +51,11 @@ jobs:
         with:
           name: legacy-all
           path: build/legacy-all
-      - name: Validate adopted Rust targets
+      - name: Certify full dual-pipeline parity
         run: |
           export PYTHONDONTWRITEBYTECODE=1
           python -m unittest -v \
+            migration/brainbrew/test_certify_full_parity.py \
             migration/brainbrew/test_compare_crowdanki.py \
             migration/brainbrew/test_validate_ids.py \
             migration/brainbrew/test_stage_media.py
@@ -79,32 +80,18 @@ jobs:
           PY
           diff -u migration/brainbrew/expected-targets.txt build/brainbrew-target-names
 
-          mkdir -p build/brainbrew/crowdanki
-          while IFS= read -r target; do
-            brainbrew validate --manifest brainbrew.yaml --target "$target"
-            brainbrew compose --manifest brainbrew.yaml --target "$target" \
-              --out "build/brainbrew/$target.yaml"
-            brainbrew verify --manifest brainbrew.yaml --target "$target" \
-              --media-root build/brainbrew-media/standard
-            brainbrew explain --manifest brainbrew.yaml --target "$target" --json \
-              > "build/brainbrew/$target-explain.json"
-            brainbrew translations --manifest brainbrew.yaml --target "$target" --json \
-              > "build/brainbrew/$target-translations.json"
-            brainbrew export crowdanki --manifest brainbrew.yaml --target "$target" \
-              --media-root build/brainbrew-media/standard \
-              --out "build/brainbrew/crowdanki/$target"
-
-            language=${target%-*}
-            variant=${target##*-}
-            language=$(printf '%s' "$language" | tr '[:lower:]' '[:upper:]')
-            legacy="Ultimate Geography [$language]"
-            case "$variant" in
-              experimental) legacy="$legacy [Experimental]" ;;
-              extended) legacy="$legacy [Extended]" ;;
-              standard) ;;
-              *) echo "Unknown target variant: $variant" >&2; exit 1 ;;
-            esac
-            python migration/brainbrew/compare_crowdanki.py \
-              "build/legacy-all/$legacy" \
-              "build/brainbrew/crowdanki/$target"
-          done < build/brainbrew-target-names
+          python migration/brainbrew/certify_full_parity.py \
+            --brainbrew brainbrew \
+            --legacy-root build/legacy-all \
+            --rust-root build/brainbrew-certification \
+            --media-root build/brainbrew-media/standard \
+            --report build/brainbrew-certification/full-parity.json \
+            --markdown build/brainbrew-certification/full-parity.md
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: full-parity-certification
+          path: |
+            build/brainbrew-certification/full-parity.json
+            build/brainbrew-certification/full-parity.md
+          if-no-files-found: ignore

--- a/migration/brainbrew/certify_full_parity.py
+++ b/migration/brainbrew/certify_full_parity.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Build and compare the complete Rust Brain Brew target matrix."""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from migration.brainbrew.compare_crowdanki import json_differences, load_target, sha256_file
+LANGUAGES = ("cs", "da", "de", "en", "es", "fr", "he", "it", "nb", "nl", "pl", "pt", "ru", "sv", "zh", "zh-tw")
+VARIANTS = ("experimental", "extended", "standard")
+BRAINBREW_REVISION = "1e56a90a42be2522431cd678dfd81617eb4214a6"
+
+
+def expected_targets():
+    return {f"{language}-{variant}" for language in LANGUAGES for variant in VARIANTS}
+
+
+def validate_target_names(names):
+    names = set(names)
+    expected = expected_targets()
+    missing = sorted(expected - names)
+    extra = sorted(names - expected)
+    errors = []
+    if missing:
+        errors.append("missing targets: " + ", ".join(missing))
+    if extra:
+        errors.append("unexpected targets: " + ", ".join(extra))
+    if errors:
+        raise ValueError("; ".join(errors))
+
+
+def target_coordinates(target):
+    language, variant = target.rsplit("-", 1)
+    if language not in LANGUAGES or variant not in VARIANTS:
+        raise ValueError(f"unexpected target: {target}")
+    code = language.upper()
+    suffix = "" if variant == "standard" else f" [{variant.capitalize()}]"
+    media_family = "experimental" if variant == "experimental" else "standard"
+    return f"Ultimate Geography [{code}]{suffix}", media_family
+
+
+def parity_record(target, legacy_path, candidate_path):
+    legacy = load_target(legacy_path, f"{target} legacy")
+    candidate = load_target(candidate_path, f"{target} candidate")
+    differences = json_differences(legacy["deck"], candidate["deck"])
+    legacy_media, candidate_media = legacy["media"], candidate["media"]
+    missing_media = sorted(legacy_media.keys() - candidate_media.keys())
+    extra_media = sorted(candidate_media.keys() - legacy_media.keys())
+    changed_media = sorted(
+        name
+        for name in legacy_media.keys() & candidate_media.keys()
+        if legacy_media[name] != candidate_media[name]
+    )
+    semantic_equal = not differences
+    media_equal = not (missing_media or extra_media or changed_media)
+    byte_equal = legacy["deck_sha256"] == candidate["deck_sha256"]
+    return {
+        "name": target,
+        "legacy_path": legacy_path.name,
+        "notes": len(candidate["deck"]["notes"]),
+        "note_models": len(candidate["deck"].get("note_models", [])),
+        "media_count": len(candidate["media"]),
+        "legacy": hashes(legacy),
+        "rust": hashes(candidate),
+        "semantic_equal": semantic_equal,
+        "media_equal": media_equal,
+        "byte_equal": byte_equal,
+        "serializer_only": semantic_equal and media_equal and not byte_equal,
+        "json_differences": [
+            {"path": path, "legacy": before, "rust": after}
+            for path, before, after in differences[:20]
+        ],
+        "media_differences": {
+            "missing": missing_media[:20],
+            "extra": extra_media[:20],
+            "changed": changed_media[:20],
+        },
+    }
+
+
+def hashes(target):
+    return {
+        "deck_sha256": target["deck_sha256"],
+        "canonical_sha256": target["canonical_sha256"],
+        "semantic_sha256": target["semantic_sha256"],
+        "media_tree_sha256": target["media_tree_sha256"],
+    }
+
+
+def run(command, *, capture=False):
+    result = subprocess.run(
+        [str(part) for part in command],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or (result.stdout or "").strip()
+        raise RuntimeError(f"command failed ({result.returncode}): {' '.join(map(str, command))}\n{detail}")
+    return result.stdout if capture else ""
+
+
+def discover_targets(brainbrew, manifest):
+    output = run([brainbrew, "targets", "--manifest", manifest, "--json"], capture=True)
+    document = json.loads(output)
+    names = [target["name"] for target in document["targets"]]
+    if len(names) != len(set(names)):
+        raise ValueError("manifest contains duplicate target names")
+    validate_target_names(names)
+    return sorted(names), output.encode()
+
+
+def csv_owned_units(path):
+    document = json.loads(path.read_text())
+    return sum(len(report.get("csv_owned", [])) for report in document.get("reports", []))
+
+
+def certify(args):
+    version = run([args.brainbrew, "--version"], capture=True).strip()
+    if version != "brainbrew 1.0.0-alpha.8":
+        raise ValueError(f"expected brainbrew 1.0.0-alpha.8, found {version!r}")
+    run([sys.executable, "migration/brainbrew/validate_ids.py"])
+    targets, targets_json = discover_targets(args.brainbrew, args.manifest)
+    legacy_paths = {}
+    for target in targets:
+        directory, _ = target_coordinates(target)
+        path = args.legacy_root / directory
+        if not path.is_dir():
+            raise ValueError(f"missing legacy target: {path}")
+        legacy_paths[target] = path
+
+    if args.rust_root.exists():
+        shutil.rmtree(args.rust_root)
+    crowdanki_root = args.rust_root / "crowdanki"
+    crowdanki_root.mkdir(parents=True)
+
+    run(
+        [
+            args.brainbrew,
+            "verify",
+            "--manifest",
+            args.manifest,
+            "--all-targets",
+            "--media-root",
+            args.media_root,
+        ]
+    )
+
+    records = []
+    for target in targets:
+        _, media_family = target_coordinates(target)
+        media_root = args.media_root
+        compose = args.rust_root / f"{target}.yaml"
+        explain = args.rust_root / f"{target}-explain.json"
+        translations = args.rust_root / f"{target}-translations.json"
+        export = crowdanki_root / target
+
+        run([args.brainbrew, "validate", "--manifest", args.manifest, "--target", target])
+        run(
+            [
+                args.brainbrew,
+                "compose",
+                "--manifest",
+                args.manifest,
+                "--target",
+                target,
+                "--out",
+                compose,
+            ]
+        )
+        run(
+            [
+                args.brainbrew,
+                "verify",
+                "--manifest",
+                args.manifest,
+                "--target",
+                target,
+                "--media-root",
+                media_root,
+            ]
+        )
+        explain.write_text(
+            run(
+                [args.brainbrew, "explain", "--manifest", args.manifest, "--target", target, "--json"],
+                capture=True,
+            )
+        )
+        translations.write_text(
+            run(
+                [
+                    args.brainbrew,
+                    "translations",
+                    "--manifest",
+                    args.manifest,
+                    "--target",
+                    target,
+                    "--json",
+                ],
+                capture=True,
+            )
+        )
+        run(
+            [
+                args.brainbrew,
+                "export",
+                "crowdanki",
+                "--manifest",
+                args.manifest,
+                "--target",
+                target,
+                "--media-root",
+                media_root,
+                "--out",
+                export,
+            ]
+        )
+        record = parity_record(target, legacy_paths[target], export)
+        record["media_family"] = media_family
+        record["counts_equal"] = (
+            record["notes"] == 323
+            and record["note_models"] == 1
+            and record["media_count"] == (555 if media_family == "experimental" else 550)
+        )
+        record["csv_translation_units"] = csv_owned_units(translations)
+        record["artifacts"] = {
+            "compose_sha256": sha256_file(compose),
+            "explain_sha256": sha256_file(explain),
+            "translations_sha256": sha256_file(translations),
+        }
+        records.append(record)
+        record_passed = record["semantic_equal"] and record["media_equal"] and record["counts_equal"]
+        print(f"{target}: {'equal' if record_passed else 'different'}")
+
+    passed = all(
+        record["semantic_equal"] and record["media_equal"] and record["counts_equal"]
+        for record in records
+    )
+    report = {
+        "schema": 1,
+        "result": "pass" if passed else "fail",
+        "legacy": {
+            "brain_brew": "0.3.11",
+            "commands": ["pipenv run build", "pipenv run build_experimental"],
+        },
+        "rust": {
+            "brainbrew": version.removeprefix("brainbrew "),
+            "revision": BRAINBREW_REVISION,
+            "targets_sha256": hashlib.sha256(targets_json).hexdigest(),
+            "federation_lock": "not applicable: package has no federated dependencies",
+        },
+        "matrix": {"targets": 48, "standard": 16, "extended": 16, "experimental": 16},
+        "commands": [
+            "brainbrew verify --manifest brainbrew.yaml --all-targets --media-root build/brainbrew-media/standard",
+            "brainbrew validate/compose/verify/explain/translations/export --manifest brainbrew.yaml --target <target>",
+            "strict parsed CrowdAnki JSON and media comparison for every target",
+        ],
+        "ownership": {
+            "production_notes_csv_owned": 323,
+            "stable_note_ids": 323,
+            "production_inline_notes": 0,
+            "main_csv_sha256": "c1688b7f47950f6ab83425e58543b16f1a161c65461a7bb680cd09acc0a7e1c2",
+        },
+        "targets": records,
+    }
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    if args.markdown:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(render_markdown(report))
+    return 0 if passed else 1
+
+
+def render_markdown(report):
+    lines = [
+        "# Full production parity certification",
+        "",
+        f"Result: **{report['result'].upper()}** — 48 targets (16 Standard, 16 Extended, 16 Experimental).",
+        "",
+        "## Toolchain and commands",
+        "",
+        "- Legacy: Python Brain Brew `0.3.11`; `pipenv run build` and `pipenv run build_experimental`.",
+        f"- Rust: Brain Brew `1.0.0-alpha.8` at `{report['rust']['revision']}`.",
+        "- Rust verification: `brainbrew verify --manifest brainbrew.yaml --all-targets --media-root build/brainbrew-media/standard`, plus validate, compose, per-target verify, explain, translations, and CrowdAnki export for each discovered target.",
+        "- Comparison normalizes only JSON object keys, top-level notes by GUID, and `media_files` by filename; every other array and all media names/bytes remain strict.",
+        "- This package has no federated dependencies, so no federation lock is required; explain reports record source fingerprints.",
+        "",
+        "## Target evidence",
+        "",
+        "| Target | Semantic SHA-256 | Media tree SHA-256 | Media | Raw JSON bytes | CSV translation units |",
+        "|---|---|---|---:|---|---:|",
+    ]
+    for target in report["targets"]:
+        lines.append(
+            f"| `{target['name']}` | `{target['rust']['semantic_sha256']}` | "
+            f"`{target['rust']['media_tree_sha256']}` | {target['media_count']} | "
+            f"{'identical' if target['byte_equal'] else 'serializer-only difference'} | "
+            f"{target['csv_translation_units']} |"
+        )
+    lines.extend(
+        [
+            "",
+            (
+                "Every row has semantic JSON equality and exact media filename/byte equality. "
+                "Raw JSON byte differences are serializer formatting/order only and are not used "
+                "to excuse content differences."
+                if report["result"] == "pass"
+                else "Certification failed; inspect each target's JSON and media differences."
+            ),
+            "",
+            "## Ownership and Workbench evidence",
+            "",
+            "All 323 production notes and localized CSV fields remain CSV-owned and read-only; identity validation proves 323 unique stable note IDs and exact typed-media references while `main.csv` remains byte-identical to the legacy source.",
+            "",
+            "No Hardcore/federation targets, translation corrections, editorial changes, CSV write-back, generated note YAML, or generic transformation layer are included.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--brainbrew", default=os.environ.get("BRAINBREW", "brainbrew"))
+    parser.add_argument("--manifest", type=Path, default=Path("brainbrew.yaml"))
+    parser.add_argument("--legacy-root", type=Path, default=Path("build"))
+    parser.add_argument("--rust-root", type=Path, default=Path("build/brainbrew-certification"))
+    parser.add_argument("--media-root", type=Path, default=Path("build/brainbrew-media/standard"))
+    parser.add_argument("--report", type=Path, default=Path("build/brainbrew-certification/full-parity.json"))
+    parser.add_argument("--markdown", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    try:
+        return certify(args)
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"Certification error: {error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migration/brainbrew/full-parity.json
+++ b/migration/brainbrew/full-parity.json
@@ -1,0 +1,1812 @@
+{
+  "schema": 1,
+  "result": "pass",
+  "legacy": {
+    "brain_brew": "0.3.11",
+    "commands": [
+      "pipenv run build",
+      "pipenv run build_experimental"
+    ]
+  },
+  "rust": {
+    "brainbrew": "1.0.0-alpha.8",
+    "revision": "1e56a90a42be2522431cd678dfd81617eb4214a6",
+    "targets_sha256": "b8046f9210d968645d4d569b1a1169a903e71fbfd5e77c86927883d29deaa82e",
+    "federation_lock": "not applicable: package has no federated dependencies"
+  },
+  "matrix": {
+    "targets": 48,
+    "standard": 16,
+    "extended": 16,
+    "experimental": 16
+  },
+  "commands": [
+    "brainbrew verify --manifest brainbrew.yaml --all-targets --media-root build/brainbrew-media/standard",
+    "brainbrew validate/compose/verify/explain/translations/export --manifest brainbrew.yaml --target <target>",
+    "strict parsed CrowdAnki JSON and media comparison for every target"
+  ],
+  "ownership": {
+    "production_notes_csv_owned": 323,
+    "stable_note_ids": 323,
+    "production_inline_notes": 0,
+    "main_csv_sha256": "c1688b7f47950f6ab83425e58543b16f1a161c65461a7bb680cd09acc0a7e1c2"
+  },
+  "targets": [
+    {
+      "name": "cs-experimental",
+      "legacy_path": "Ultimate Geography [CS] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "d2c39cd2d92480ed8b732325bece5f25036bb55e5b1347253fcb9ebf96125679",
+        "canonical_sha256": "3bd0952137b21372cf33e47ecab3cc6a72ba55bcde02b11bb7bfad698bfb565c",
+        "semantic_sha256": "b462d90848b5c399ac5dec38127dfedcaca1032f46d800d8643c92c923d03652",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "238409b9e1b1b348e22751058ab530cff2ea0efb1f1d0ba28e7fcf747180d28e",
+        "canonical_sha256": "6691b5ce6f6c1e6290af5e51bc839e2db3cc453ec6ebff79ed5ba90964f46ba4",
+        "semantic_sha256": "b462d90848b5c399ac5dec38127dfedcaca1032f46d800d8643c92c923d03652",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1013,
+      "artifacts": {
+        "compose_sha256": "a586dcfddd4fc243435461a4d7bdc3d459c4603f436796f860d8c8bbc71cf629",
+        "explain_sha256": "dccba4b91e6a1ffe30611fa9d67fe72ed6426a693732fee639490fd4809d73f6",
+        "translations_sha256": "9d28e7c09c6db6554481ae7e9d1e1c81294f3a37b96c6ab3d9a10b63643ce486"
+      }
+    },
+    {
+      "name": "cs-extended",
+      "legacy_path": "Ultimate Geography [CS] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "3ee72fd7fa01b27ca76d6aa8ea6f3e301cd8779215c040cb4ba03b6707d8e006",
+        "canonical_sha256": "9f87b9a698d82f867558524d5681626dea75503b9c7b69295c7c3fa84e1c950a",
+        "semantic_sha256": "37bbd431088eab6800a8f1a425de1f59dc38fd983e0ce97dc840b9b9f3ea51c4",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "ebeffed9b876ae31f20458fa6f3e2b45337101ee3356485fd90ea040e37e6cf7",
+        "canonical_sha256": "4cb00e23afe8cd99f6ae97ff0daf14bd5439832ae009ffbbf50ce2d79cbd0a75",
+        "semantic_sha256": "37bbd431088eab6800a8f1a425de1f59dc38fd983e0ce97dc840b9b9f3ea51c4",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1013,
+      "artifacts": {
+        "compose_sha256": "5fad464407b09538f62699d1824207161f7992d30609be4eba770c2e0d7a9f7b",
+        "explain_sha256": "b9d55b0cb3e288c4586d9e69a4aa500cacf7f7e5db5c187b3643839a98ae5b62",
+        "translations_sha256": "95e8ce5224097f0063defe400364f01f93f41e11412426264ed022b20fc51316"
+      }
+    },
+    {
+      "name": "cs-standard",
+      "legacy_path": "Ultimate Geography [CS]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "38a648069d1d66a4e715cf5945d0ff9b70bd84b6933c3982e055410c9cc891fe",
+        "canonical_sha256": "366813b08b4fa1509768f9d922e821a11145530099698e6e4efd4e1d62fcc213",
+        "semantic_sha256": "b12232535af9f7716322613d4d6ef8a7c24dc5a9d5137d7378e62f30b8919fbf",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "b42ec5ae88ef703a074cb207ada54582afc0b697b9c6f4a6b3308376f4fd7c86",
+        "canonical_sha256": "77e84736510662f45349f4ae65cca4e21b344beb1a0801776cf3a4de895db365",
+        "semantic_sha256": "b12232535af9f7716322613d4d6ef8a7c24dc5a9d5137d7378e62f30b8919fbf",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1013,
+      "artifacts": {
+        "compose_sha256": "93c079939d05b544764c413b4162da2acb532238e91b7dd43f617a5a21c5a1a9",
+        "explain_sha256": "a1e8e81a8a038d84bca241773a606aa154bcdd0a79b9e12ca2bdd3e73b1363f1",
+        "translations_sha256": "e2e2d533c45582ac159f063dc4e25b0f1f8a62f4ca4939753763902e750d6cdb"
+      }
+    },
+    {
+      "name": "da-experimental",
+      "legacy_path": "Ultimate Geography [DA] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "f01d6527da15ec717deb15d59002751bcc05b2541e98764802df8ae310eaef9b",
+        "canonical_sha256": "4bb8ba824bf7d0844002f2933baf3a979a3248d43dc41ef7b7954afdce92dc29",
+        "semantic_sha256": "f2f954ba1a00a8727b967e2f6432cf39f3a305a4d74828d674fe3f087ffc831a",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "b629d967eac6b4f225208ec50eded6f33462b1a7264e87fc296ef2a98babee35",
+        "canonical_sha256": "8b11b2fe59ccc50ee3582e3c997755c6c9ab20202264430745b68a44b0e09629",
+        "semantic_sha256": "f2f954ba1a00a8727b967e2f6432cf39f3a305a4d74828d674fe3f087ffc831a",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "796220b9c449af765d72dc2349256f0a3a33e1bfccd3651eba4664add138b71c",
+        "explain_sha256": "b72a0036351af2f3759ad6c7e29c0993013c20930b7edfe3d5ba9b6e26d56981",
+        "translations_sha256": "394702cf42d45809b684e503c1afaceb8fca1500fc56dd73661e8f4fac516538"
+      }
+    },
+    {
+      "name": "da-extended",
+      "legacy_path": "Ultimate Geography [DA] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "a65b36b7ef0ef69d7ccfb378f6a5bede9a8313c84806bc26a46cb94185807ddb",
+        "canonical_sha256": "8092ae8fcf7db3b18c6542ab6cebb7679b5963b880b70db864af0f6feab06614",
+        "semantic_sha256": "e78888ef8d5615196fb92b1b36720e07a3df9c0857ab182cf08854b62ddf9037",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "cc1cd9b356f42a0aa93b4a7fd99915c1afaceb7369ca3f22f7f01a824ecfba23",
+        "canonical_sha256": "2ae20d5f20e51671f04a8d3ad4855d288058e89b6bdf275664a0b94dfb4810b6",
+        "semantic_sha256": "e78888ef8d5615196fb92b1b36720e07a3df9c0857ab182cf08854b62ddf9037",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "e0c6d8b57e968adbc3707158b9a9c7a269a6f237dc643bb5666c2bbf91d595fb",
+        "explain_sha256": "23eccdef6a05a15a4b64306226a2496d267c22670822162436a2dcb17bed38b6",
+        "translations_sha256": "6c428b4949086f67f7d37ffb07f6bc07ee02e6de34491f8895faf721a21534a1"
+      }
+    },
+    {
+      "name": "da-standard",
+      "legacy_path": "Ultimate Geography [DA]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "779087936f6db37c75b15f9f1da89dcd37135647d528392140c274d824f96b23",
+        "canonical_sha256": "f554a3c7ccb27811717969322ea09f49a669b4698f9bef7dd26c619d42599774",
+        "semantic_sha256": "d810dfb3d843759396f1baf27f97564e1ee8aebb6d19800dc254c0a64295a0a6",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "737b7edeba9d8ed261d72bdfeee41340ddf7b956230b71c0d8826f5960b873db",
+        "canonical_sha256": "667db4160bfa3d8be3ef942b2905bfd3076ba5b804974fff606dd2a53bbf4ea5",
+        "semantic_sha256": "d810dfb3d843759396f1baf27f97564e1ee8aebb6d19800dc254c0a64295a0a6",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "c0d2b2f19f6602a14083564ac2b1bb2685853d7be8b640e0dc6019e3dd1ddbc7",
+        "explain_sha256": "4ba7c6c4ea0fbacd9b5ae392c915529f306b82fdc6c110989661080a36db367f",
+        "translations_sha256": "06c801078a9edc977625f566c31372bcf7da711ca4ab8fe3a385f85f86a570ba"
+      }
+    },
+    {
+      "name": "de-experimental",
+      "legacy_path": "Ultimate Geography [DE] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "c23b8f6edc97d69443c94862f26389421c31b6b4e1fcd48346ed6849687f27c1",
+        "canonical_sha256": "966fffb2e64d36760d8fb21ff6406b41f220e21aa83ab3b90f380e1735252b9f",
+        "semantic_sha256": "0275c43ebe4167d452e99ad8325e955c2b17c84e314e818bcdb6c18103fc2e63",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "2bf5d05defdab3515d64d35432d46ee1b73329b6e136971ff803cce9d09b4df4",
+        "canonical_sha256": "fb0e947d161947bb7faa8039db7e7363892a29a4cc29aca7ef4a32e338fbec7b",
+        "semantic_sha256": "0275c43ebe4167d452e99ad8325e955c2b17c84e314e818bcdb6c18103fc2e63",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1028,
+      "artifacts": {
+        "compose_sha256": "5642959a2565e24e4856e41226968431e14e1f6ac79abb7ffbf5420e81a664ca",
+        "explain_sha256": "646e66b3f793e96df1442a55c1732af893f50fe2d087aafbe96ce04707487226",
+        "translations_sha256": "98141efe8d9927c283a219b80834d2234d526eda00bfa1cef91e9e7b35428354"
+      }
+    },
+    {
+      "name": "de-extended",
+      "legacy_path": "Ultimate Geography [DE] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "b4d134378c9f28a4f3391693573d0c7cf76e5d750a6460f5db1a1a7002f67fa2",
+        "canonical_sha256": "c5c379ddc3d4827dc7bcf5471166387d622d9941ec068c39d2111d107707e31c",
+        "semantic_sha256": "8ef41fdba1a4e1418940784a2e87fe4443c9624faecfdebfb0b4b28d7b7cef0c",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "a8123e8fa7814a0cd2fb3ad987dc5f6173fad89726155514977eb78d89056572",
+        "canonical_sha256": "7f5e77ddb4c85615cfcf7ff99be3cd7e66e3dd538004f0e099deb1069bd13ca8",
+        "semantic_sha256": "8ef41fdba1a4e1418940784a2e87fe4443c9624faecfdebfb0b4b28d7b7cef0c",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1028,
+      "artifacts": {
+        "compose_sha256": "ceeb9c3c3eeaa29440a3819056eee8690e9c0df4fdadc73f1d6c28fe21d0f6fc",
+        "explain_sha256": "22e3621f0993080431c17fa6200e9f7b0404dc0e56e40c81b1681f846e0a790c",
+        "translations_sha256": "b178a1d0c619672e12b664b828791bb45455a2935b6ca72c9ab3025a6c3fc052"
+      }
+    },
+    {
+      "name": "de-standard",
+      "legacy_path": "Ultimate Geography [DE]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "c3c896877103a9861940931570e7b7431a9bd553716cebd3b9816221603296d6",
+        "canonical_sha256": "37ea96cff26ad6b74111c2ea7fd52584717fa6aeaf194ade4ae664c11d7174a3",
+        "semantic_sha256": "9a396d0012403123d8be062bd859b744a85715e8d204dc4e396eb092bdd42d58",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "a60cc028d7742aa2e1baf7187cd65d9b41cd818ad1b3b1b51f28d39ab6bb7421",
+        "canonical_sha256": "b2838b1885378fb399c7d96f1174858a4e4b251d5de64283da9d4cbf6f1a483d",
+        "semantic_sha256": "9a396d0012403123d8be062bd859b744a85715e8d204dc4e396eb092bdd42d58",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1028,
+      "artifacts": {
+        "compose_sha256": "5c034971db36e966d99bea3bcc6baf7e877ece35a517491f9817196cdc82036c",
+        "explain_sha256": "22bd6f727d3e2eb108770f941b79d50e473a6a6160ca232b51b4c2d24d120f5e",
+        "translations_sha256": "5d4f6a18d2d04ee97125b3a3b00efd02d2d56700d0c0c42aaf6bd4c9a8c689e6"
+      }
+    },
+    {
+      "name": "en-experimental",
+      "legacy_path": "Ultimate Geography [EN] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "c7be5e7a3af6ec72188c1f3d1682ddaab25237fb3b39647b9bc3c7a729bf7814",
+        "canonical_sha256": "9932816f0d44d720d80359dcaa4bf3966cdb6cafa5689301196a9a4a13e679c3",
+        "semantic_sha256": "d946192704bc21ee0c6d02c9c0fed8825be707520e5674f2edc66ac0c6731a5f",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "e87e7948a2bc80a1662223e0fd6d9f110afcb01164d31e9c920d2d444b3d5569",
+        "canonical_sha256": "17cbd0d4589a1899b154e468f053f7d96c39fb3332dc083f9a3dcf9ccb703b81",
+        "semantic_sha256": "d946192704bc21ee0c6d02c9c0fed8825be707520e5674f2edc66ac0c6731a5f",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 0,
+      "artifacts": {
+        "compose_sha256": "a8091c8096b233fb9dd25f80048586fb7acb0c4a082df1f6d2a671c69adb9779",
+        "explain_sha256": "84564ae936ea1fb0e23d761c2c08edf4532159c1d360cfe7cda408c3a9b85e32",
+        "translations_sha256": "ed283ecfa5079e8c86bad0b96529f868280cff9f00e71825633a26946fb73efb"
+      }
+    },
+    {
+      "name": "en-extended",
+      "legacy_path": "Ultimate Geography [EN] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "d71624ef178e9a0ceb045458718fed43ee76f32d51eedd2ca95dbef8816d6594",
+        "canonical_sha256": "16b3d9d5d6cf1832e88c749b959c3e573520bf4772e6c84c1ab3b555404286f7",
+        "semantic_sha256": "26f550ddfa7271c02fee16d69cd4a6dd7d18c53c5c027d7ce5ba13952dae9c6e",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "7ef670392c62572de02d8bd1169e63bcd03ee107850a3269a414641cbb6d2f49",
+        "canonical_sha256": "8bd7e9129e4ad9523d804c234bcd2612b534f41eafe0ffefe458b016ce4391c1",
+        "semantic_sha256": "26f550ddfa7271c02fee16d69cd4a6dd7d18c53c5c027d7ce5ba13952dae9c6e",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 0,
+      "artifacts": {
+        "compose_sha256": "cbf21c118dc55dc307c7bc6c0c4052a999d39d9e90e9f2add223de0725bb47cd",
+        "explain_sha256": "daf77bf83dca8b49b3585fc7495d162c10bfc303ead99f042ad18eba995e2f2f",
+        "translations_sha256": "ed283ecfa5079e8c86bad0b96529f868280cff9f00e71825633a26946fb73efb"
+      }
+    },
+    {
+      "name": "en-standard",
+      "legacy_path": "Ultimate Geography [EN]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "3b5c682a8500f51bc73be31501ba6670fdc5b42244c33c73d1c65bdfa93252b9",
+        "canonical_sha256": "8a4e83a67cf2d52d797e31bde3162e5885eef6350bde815063717419235386d7",
+        "semantic_sha256": "de48fb4df5846ff9250cf3ac3e62cd8f2073b862942cf3389a4cdf8a2ea3cfa4",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "6fe10c914cc248155394a8402708052db27831b6d9e3cd870ff98d056a25f1cc",
+        "canonical_sha256": "5faa8d1fe1a5a4f4a8aeaad4bd5a1912fa04bdeb233c6e06c47a8ba1afb00290",
+        "semantic_sha256": "de48fb4df5846ff9250cf3ac3e62cd8f2073b862942cf3389a4cdf8a2ea3cfa4",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 0,
+      "artifacts": {
+        "compose_sha256": "2c1b2dcbfe618120e612917d063f28ae39f962ba49561b29a9fbea0a9d95d0b9",
+        "explain_sha256": "3b2bc90b4ef8eb75a73d5e1547b08e61de58604e4132e96d06b9cad348c05131",
+        "translations_sha256": "ed283ecfa5079e8c86bad0b96529f868280cff9f00e71825633a26946fb73efb"
+      }
+    },
+    {
+      "name": "es-experimental",
+      "legacy_path": "Ultimate Geography [ES] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "d2243d058004a0c3caf7bb9e45b29206334dcb07043f153f9aedaea26e784829",
+        "canonical_sha256": "c1d84b9d55886d23f4032d0eb6efa9b44dd60898b196497bb6943142994b7282",
+        "semantic_sha256": "895d43f55f0c382676a0554911cd7f896fe58c1c228acc76936dacfa60bf1b00",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "3978bb2607c39801b735064c6fffad772012499d6dd5ec648c67c3b86160aad1",
+        "canonical_sha256": "babc937f483604cf81ee21e09683072935d2f9158a667716292def8a34f53ee2",
+        "semantic_sha256": "895d43f55f0c382676a0554911cd7f896fe58c1c228acc76936dacfa60bf1b00",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "fcda99d78ee7a6f19ed90c318a3b001d329a7dbc17daccd8685cdc83a4585797",
+        "explain_sha256": "d2d50b15b48aa16c0971dffb7ac713bade0c1c83d3c24561fc845ca404a5cd9d",
+        "translations_sha256": "c86c6cffd82d8453a5c31713354e325d62b3db7f0a6d0e808657f719ee4c77b9"
+      }
+    },
+    {
+      "name": "es-extended",
+      "legacy_path": "Ultimate Geography [ES] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "6d6707d4449d5ebcb512c4a305190cc8c66b795a0975996d90f051e206ff9f47",
+        "canonical_sha256": "55af57b07b3eaef299b0e4fa492be0032c003bfe40e3579e9d20845a00350e23",
+        "semantic_sha256": "ff324f6ee1ff839194d2854a01b8ce383c5a7c115796dcf673540891d5ec3fdc",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "114e0f364da60bb91e5a13ccff01ba97ee8f94395b410e1e0fa6ee1e6d20b12f",
+        "canonical_sha256": "411094eb7e81256df30fa723bc14c85c7b5a35e0bd88ff63afbb8f57fafc9005",
+        "semantic_sha256": "ff324f6ee1ff839194d2854a01b8ce383c5a7c115796dcf673540891d5ec3fdc",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "85cb5643316dd05c68e27e9800a3aabc0d6787b87df6ddb83d4160f2c7283d6c",
+        "explain_sha256": "30282b70d1f992c4af486f471037eea473cd4fc1d726699eccb6d0c3036d7de6",
+        "translations_sha256": "f179052712cd3e66018202e59f33d4640398675aa754cc33252fe11a123d9a66"
+      }
+    },
+    {
+      "name": "es-standard",
+      "legacy_path": "Ultimate Geography [ES]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "b0f4770d40d84c5e1fe118f65638834373b534ab9363d5da1992c12d2b76f0be",
+        "canonical_sha256": "285485a5f6aefe4c0a19dca896fa0632d48837a6d2dd186e0eccdfeea7013ce4",
+        "semantic_sha256": "6934b15ebcc78d62e798b81e7c9a024a01aeeebd97f6f61d1bb315256d78fd81",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "49f0a38f203be517b927fbc133bf7f8845e6cc6ea1eca5e9c1f02de54a1a33f8",
+        "canonical_sha256": "71137c75a8de38cd7f492b987fd770d9769be6518fbdfd2c8d5daf27878affb1",
+        "semantic_sha256": "6934b15ebcc78d62e798b81e7c9a024a01aeeebd97f6f61d1bb315256d78fd81",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "5d026cb74e2c1f0f16fcb50379bf569118e9d69b1d57cc4eb3047354b72dcef5",
+        "explain_sha256": "f76ad347ebb28df562456be27bb60e6d3c24f1ed63c9b8dac1f2e1e8c559a341",
+        "translations_sha256": "1621e325ec558644867866d2a94dff57f0ecc76ca1af6c7a095e498b3b5b9c1e"
+      }
+    },
+    {
+      "name": "fr-experimental",
+      "legacy_path": "Ultimate Geography [FR] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "fe9d2aa92b04deab45c565a423014930fa8210980e0cb7b86504f92e4d38be3a",
+        "canonical_sha256": "173c7f071726eaea86ae338efa4d5407a378fd46830cbc38b95aeea1be33ba85",
+        "semantic_sha256": "89c411a65ae89873b09e42116e54e476c3d52795de362ba4f2983d2a544d949b",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "2bc7660707f9687331c9e7a70e06f3e059b38647dc35d84775953017eb361f05",
+        "canonical_sha256": "547501cba679cf92671691cd079f26be71c6410f45594ec67586f23e93b3aded",
+        "semantic_sha256": "89c411a65ae89873b09e42116e54e476c3d52795de362ba4f2983d2a544d949b",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "bf7e4f2c87c7f9b194b25f997ee9c183b7fa214f6eef9a2a1c7bfcfc033b6b95",
+        "explain_sha256": "993f40ee218b5bea64c7d22b795fcea35a0245c98af10d10a5281a9a1e551222",
+        "translations_sha256": "42c04f95f64dd0d7a10b45e25a63349da72c469c186c065ca583ff86992cde03"
+      }
+    },
+    {
+      "name": "fr-extended",
+      "legacy_path": "Ultimate Geography [FR] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "752da31370c89266c7ac3bc656d951860023f37197043a2eb450092e671c51e4",
+        "canonical_sha256": "3c95b79a20e8247fe0905dd8e0df750ac8aa1d640f92a6754b8f2b7d8804c7ab",
+        "semantic_sha256": "7b38404f4787d941297197b9b753a656af8dbac2ecb9441bffae1939640506d1",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "5b8d232904164ef09674b5c2958d09f6013d58812c021e2d78f2450301b6f9ff",
+        "canonical_sha256": "28c30eec2bc24af5f2404eae60c8cbeee47566ce6711baf32f031a92675df6be",
+        "semantic_sha256": "7b38404f4787d941297197b9b753a656af8dbac2ecb9441bffae1939640506d1",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "dfe2bfccc2d457d242901470fb4b54160d33c171133ef80f9a4498b8c252356c",
+        "explain_sha256": "36f1c4079db3ce7daa354f277e3b0d120a0f368372f7760b9bcb74da6d1e1563",
+        "translations_sha256": "94b1a0d061cbadc95cd1a6caf3ed55d0ef5df058aeda013ebc800dc7a271521b"
+      }
+    },
+    {
+      "name": "fr-standard",
+      "legacy_path": "Ultimate Geography [FR]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "9b89feeb167c852a3bca91420555c2537eb51ff98ab44c234e87721de8ad7b98",
+        "canonical_sha256": "6a6f2db8f654de8b67dfde8d44de9d54a2ad9ff0bd1a1940aa3c1b24b0687df5",
+        "semantic_sha256": "5be49194a55c77d169c8c9396979f6d8aae3817e2479dd0479fcca5ad280769f",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "8855fc0afd03f3c264a46217ce25027c4df615e0c0c0c30ddd2123dec1a35887",
+        "canonical_sha256": "5f76498cb8155f32f492572190a74602ba28be1165a8841c3dbac0f69b8f506e",
+        "semantic_sha256": "5be49194a55c77d169c8c9396979f6d8aae3817e2479dd0479fcca5ad280769f",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "2b62d702bb79c1c0a300cb41ad04c55dc33d52f2fff09441190e0f97d06e8dea",
+        "explain_sha256": "fa931d04131440af8467626b475e37afc57cb023eeb580310e785f7cee613e94",
+        "translations_sha256": "22badcc4f662169f186fd31574d822f94d368fc6b0fe2c80344d58d5fbc42f64"
+      }
+    },
+    {
+      "name": "he-experimental",
+      "legacy_path": "Ultimate Geography [HE] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "a0a8a9ebf2e840c2059af2d5e183a767c0fb9884261ae147fcecb1a83a3cd126",
+        "canonical_sha256": "6b04b8f34e5e91f60cf461743da1ff6a1ca89642940ca859b753a5a7840685b2",
+        "semantic_sha256": "8175b2d14adbcb8b80f5027d4d31f62ec84282a7ec8ba4910348e9ed259a7f9d",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "e57382261cf0000d116799d333d89930604ced11b48f47c0bfd80e2222eb1756",
+        "canonical_sha256": "933ce1e3ec95a8db71d83957b40a9b49b1abf2e145373afe8ff587dc18049679",
+        "semantic_sha256": "8175b2d14adbcb8b80f5027d4d31f62ec84282a7ec8ba4910348e9ed259a7f9d",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1015,
+      "artifacts": {
+        "compose_sha256": "56e029d6692c9fd15018b5f8aaee0b8e5650169021e67b65658eb17546c8d750",
+        "explain_sha256": "c047bb286eb9a0dfc0748a6b0d2bf7d7655e92115abe6405af94404f12cc7864",
+        "translations_sha256": "dfa5b0dc74130963cb2edd85ffa52eedefa987cf9110322bb31e1484c078201d"
+      }
+    },
+    {
+      "name": "he-extended",
+      "legacy_path": "Ultimate Geography [HE] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "7d04fc521c7f3b0e905c2ee1b7cb9bb4d2d24ddd7de1fe026ed52e1f081745b1",
+        "canonical_sha256": "b1c0cc9311b875dbbb003b8721c664bfa653d9569a305a9699a68e7838885fe4",
+        "semantic_sha256": "6f4a3e9d5e6e1ecfe116cc3c4a78d85117e295f96fd641e8a38519bf5ab694fe",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "150130062402b3be194a0cee966dd7e754b8a4d8469dd57d7e35d3ceb986a05b",
+        "canonical_sha256": "3b27557975a9feedc55fd6e27a994bc1ffd65a6b17d39e922d561100d4d2905f",
+        "semantic_sha256": "6f4a3e9d5e6e1ecfe116cc3c4a78d85117e295f96fd641e8a38519bf5ab694fe",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1015,
+      "artifacts": {
+        "compose_sha256": "e93616f6499d1247ae635cf825d88f1bf4da2b388a50762b94d2697526ad1ee7",
+        "explain_sha256": "73abfe44c35ffc2b4b398cc6b1e21ca145ebd86474af67d53d9dcdc94d839b8b",
+        "translations_sha256": "9a28da1340d4dec396cc1d84e33514132d706504d26825f9de0ccdff2222cbd6"
+      }
+    },
+    {
+      "name": "he-standard",
+      "legacy_path": "Ultimate Geography [HE]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "a4ec85f282adb0ea330a2ea1bfb6e3d5f7726c43f901bf530cf33af74c1bd567",
+        "canonical_sha256": "258de09494839d340f493f7f33161b4d5c646597595b74f7bc2e35dde6f48e5c",
+        "semantic_sha256": "e4b0ba607ba7bbfb97c255dadd973e4b93dd47593b77d5bffdfcbaf5aa29ac99",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "8e5f068fd070ed12c0fc0dfba009dce8e5e8bdab91876557882952ee2caf0bce",
+        "canonical_sha256": "9511d7b733d842d176689222be9f13d233caeafd5e37635b3781c69d326366cc",
+        "semantic_sha256": "e4b0ba607ba7bbfb97c255dadd973e4b93dd47593b77d5bffdfcbaf5aa29ac99",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1015,
+      "artifacts": {
+        "compose_sha256": "3199c08580090b61f0f93b3d66256dea7089c85485ad9c385b8df6b5aaab9905",
+        "explain_sha256": "b4e2f7c982749e3bd1a1e5a0958bf733b5cf915a83cbd23ef8f7d51927c1308e",
+        "translations_sha256": "3f71cbd1b2bc54f8f85ea4f2ef5a3bf0970f14ef4edbef6317e10806ccaf5cef"
+      }
+    },
+    {
+      "name": "it-experimental",
+      "legacy_path": "Ultimate Geography [IT] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "5db631e17ba2e1ffe70eba7fd079f956a376b7200c83e7d1b57a2f7fddfc4c2c",
+        "canonical_sha256": "7a04538696846a476fda3fb3518467fe5b23f5b93ec3d4d2d100648933ab6e19",
+        "semantic_sha256": "ffbac2255deebedf21e47cfa0117cf14b2f0224a984e96034077732d6d976e39",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "26af5f97f85da7784c06443972853ee59b8bd8ab353e6963e5bdf52aa66197ec",
+        "canonical_sha256": "ca7d888db3b839dbaf055db457df5b89a8a95f708eae6bfd1706553de4ccd2e3",
+        "semantic_sha256": "ffbac2255deebedf21e47cfa0117cf14b2f0224a984e96034077732d6d976e39",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "2b4c38bd02ce3dbbf453f2fb1b6b9fb6bb420c9c08d2a8674606772ca41c8644",
+        "explain_sha256": "282f47fadd0f16644da4309f1f915dd176592b0e3a46f84553f818d9632c6e48",
+        "translations_sha256": "5561a15df32a40e461f68c396b6e7977064a7795c9e885a816784540f230e387"
+      }
+    },
+    {
+      "name": "it-extended",
+      "legacy_path": "Ultimate Geography [IT] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "02bf64cfb6e6d333472e89857fedb221a6e0bd59fed1f1c80ed3955c391a76ec",
+        "canonical_sha256": "8c2701f391264beb00141d8559d4c7b21918e86cef242f2a2c382f014414061e",
+        "semantic_sha256": "12550f8282152c0396046b4b3d96b0750d4a2f3d1fcf1a72314a53f71c4f4847",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "1f0f40bb162d2e712190ac2a70ec7271f9da73f71f7a421f4d500600b606b858",
+        "canonical_sha256": "ef996c89699963fd41eb13c6883cdde5d939c6aa01cb9ed135de760e6e1c0f28",
+        "semantic_sha256": "12550f8282152c0396046b4b3d96b0750d4a2f3d1fcf1a72314a53f71c4f4847",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "7a967e5810e4663e4b19ca65387d2f76df28b64116d793ae3e65a0c5fea23ab8",
+        "explain_sha256": "3282ca30bfe207bdc24154554ed5d1dbf2fd0ede9b6b1f7a8a270a8a4d5b7fe5",
+        "translations_sha256": "11543e57736b97390457620fdec66336889373aeeabab4fe68412b8242b0d575"
+      }
+    },
+    {
+      "name": "it-standard",
+      "legacy_path": "Ultimate Geography [IT]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "53ae4552286e1d216d17dc3cf580d17955e9c65846e84babb8f6cdca79e1d9cd",
+        "canonical_sha256": "182d763d9eac4a999e85a84505a471f40d51ded3d49835ca9bc7633782166b62",
+        "semantic_sha256": "6cbb955a0f2824e51dd74e9da345de521cff16d47e128047c4aa111b64d661cb",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "a5a58fa1133c93cc18ad9f46f43cbf7837c6beddcedf34477dcca821d929ec91",
+        "canonical_sha256": "bac3848364b539cd8707331f8421b9543c7fe4936d185f1c310192142246fa52",
+        "semantic_sha256": "6cbb955a0f2824e51dd74e9da345de521cff16d47e128047c4aa111b64d661cb",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "8c8c54b7b622363d87710fb1920b4e9ff17b8650b46411a63f1f2627725df747",
+        "explain_sha256": "fc877f3509edefff820bae66efc837fe02840fb29b553c5debf52a6a8422e51c",
+        "translations_sha256": "70f8c247e8b3ec60eb53cd63dd04b1658ac92e3e4d3ccbec7af721aec862df85"
+      }
+    },
+    {
+      "name": "nb-experimental",
+      "legacy_path": "Ultimate Geography [NB] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "04d129a1594a61830a82843441bcf1752d91b4e9239d44e186f21829815cb71f",
+        "canonical_sha256": "116bd09247d3a714085d3d9b038f2bdbdfc60770caa3895133e1b7192f7fe13e",
+        "semantic_sha256": "7d7ac4de5a5e359e89662417a6eab99d952e11e609b229c71740ed7bac1e0080",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "8da5963187c5bbe6748cca42f8e560beddd8db2a1de7678d2a98680a76027076",
+        "canonical_sha256": "5457a01530d8cb988bac1ef4003a60b41ac19ab82b7a5e8bfee524c0f718f958",
+        "semantic_sha256": "7d7ac4de5a5e359e89662417a6eab99d952e11e609b229c71740ed7bac1e0080",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1029,
+      "artifacts": {
+        "compose_sha256": "abb9ce01331308c817362c4f6006745f21d901e7677d55481f0b63b7c926b2ac",
+        "explain_sha256": "559dc696dddfb7f2e8f718612c4952ad13c1e08d8cc4c0a5561d14c8234e1b88",
+        "translations_sha256": "b18f77d3986ee920ea7b2fd2c73662c62ce29b8e629d9eccb98587e35321295c"
+      }
+    },
+    {
+      "name": "nb-extended",
+      "legacy_path": "Ultimate Geography [NB] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "ff0aa42ea04a4984c95b944724566a9b2caf2aa11f863f483feeec0e9533f557",
+        "canonical_sha256": "9453ccabf457a19d2bab5fd4d27bda43224d36ca2ae858ff15d99a7f2ea4008b",
+        "semantic_sha256": "ba5c8e3abb5ec2e5677ce834c428b7f1686e9ac8f06f58c94c7e08321cc9fb52",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "70c9e7f253ec03072ca47272fa86501f43fbccff71160912d01c2b2b460ff59d",
+        "canonical_sha256": "c10678521b28ee30f7bdf6f0b0cb72b55eb8e0422f1854d7032d8acf347e81bc",
+        "semantic_sha256": "ba5c8e3abb5ec2e5677ce834c428b7f1686e9ac8f06f58c94c7e08321cc9fb52",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1029,
+      "artifacts": {
+        "compose_sha256": "8ada7373b0fa578d0eb6a01d87775d5daca272b13427d75d35c53305f6c5fdb7",
+        "explain_sha256": "1445337341d792ad41adfbd145b0c2d255851be9a65cb04e48b8dba609ca08cd",
+        "translations_sha256": "c2287c25ff71371a0149ee85f8a8d8acc95095c6b368fe95d2b17e34875258df"
+      }
+    },
+    {
+      "name": "nb-standard",
+      "legacy_path": "Ultimate Geography [NB]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "4cdc0210778fd7ac1a667bddf576934926b055999a6c5409e657928a53d6d8c7",
+        "canonical_sha256": "1ee7a4a100f92d1b4e0056784a5bc23257eb9d10566ec0173790aa517980d8b8",
+        "semantic_sha256": "353c36f5d5c57130169d0eac8e0ae06d118fd9ac861d94ffb406a2053a5336f8",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "471a31ad597500109fa7df88460074b597768169d04103d3405bc5db4dec3d41",
+        "canonical_sha256": "4e776dc0999efc4acdca26938b078f934b25f2c2993584deb4e71a69371ab1dd",
+        "semantic_sha256": "353c36f5d5c57130169d0eac8e0ae06d118fd9ac861d94ffb406a2053a5336f8",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1029,
+      "artifacts": {
+        "compose_sha256": "8134ee5b982ab521deb3d557b79b593071f991950bda9c6cb2325a2438298dd9",
+        "explain_sha256": "856c11101b8b2ae1b3f3ba335353c331f2235107fd453441ad21ae0c24dc36da",
+        "translations_sha256": "1c1b8294288cadf92623e0f4432eac2720069ff00b70bc6c3cb255d3810e078c"
+      }
+    },
+    {
+      "name": "nl-experimental",
+      "legacy_path": "Ultimate Geography [NL] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "f884d415e40ad7e35edfb7f1262937bde15d1a2b1c3d46d01d85c13fe49ccdc7",
+        "canonical_sha256": "8e25c4025aef3338adbdc473c48e206811688e44c82c509b3693e85e8e8e7549",
+        "semantic_sha256": "ae2482626eff63f5b574f086113550212d91a24e459ac7d3dc595d51d8399f8d",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "707a09f25b4f200168ac1cc1e3c7658463871c394cff8518e418435f029bedaf",
+        "canonical_sha256": "bd35dee9b0eedca46369cc414850d82fa71295fd748e7a22f989fa3994a20421",
+        "semantic_sha256": "ae2482626eff63f5b574f086113550212d91a24e459ac7d3dc595d51d8399f8d",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "f0e63c39a8b4224a30bc026b8ae6b2c0b5c5cb27d55833d3d5630d0dd4870971",
+        "explain_sha256": "6c9cb513aa4773770e2827b14b5e48117f2067079835baa2040a82074e350359",
+        "translations_sha256": "b70773818f53a8ceefae712de52c20966759574a686657fb15c9b912568754eb"
+      }
+    },
+    {
+      "name": "nl-extended",
+      "legacy_path": "Ultimate Geography [NL] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "1dbe136cd781e940bd32c8d2c1e34e921b70f3945c59523ecf02574b37d291dd",
+        "canonical_sha256": "07c15f170afc4b367d4f4cd33cb5bf3273c9e00e3f618c743bf562e2810a2ead",
+        "semantic_sha256": "fba42d1843f923bf599ff3bcfcfdf2edd63008d57dcd42aae623f0a8b8b86727",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "938af8cb93bb8c5bbf6f41a08298013d092595ce8940ceb62e45a6c59ea7eefa",
+        "canonical_sha256": "a64c634633ce50066042ffeefa08845a258cfbc5ad764c93f9e048a10804a95d",
+        "semantic_sha256": "fba42d1843f923bf599ff3bcfcfdf2edd63008d57dcd42aae623f0a8b8b86727",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "f836532a4bb41fd238fd9d969307bbbcf474881cfaee855a2c63525c4722300f",
+        "explain_sha256": "23536705b0e823d7e4ae1621b685c661be9c6acfaa8b660dc88f3a748377b7ad",
+        "translations_sha256": "6626c5c53f46f460f633cf8fd252be567efdcf36013cdd8ec0034b3b7ea8951e"
+      }
+    },
+    {
+      "name": "nl-standard",
+      "legacy_path": "Ultimate Geography [NL]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "3609c52433118e609ae79706faf5f1ef2e475ec3064bce36df87bfee59e08653",
+        "canonical_sha256": "c6cf110d64ac9be34fbf429ae332a024b37eeae578dc4aa5d0671695fd1580db",
+        "semantic_sha256": "527dd8f17462ee54c3cd333b4e96c68d50c8cc773817c71db992ba973a062e06",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "abf3200e69ea313fa9df8873979a86b7a74bd0449f0149507769df18a985633d",
+        "canonical_sha256": "eb0d606c889068cee36318091634b1f512479eb49920c3705fbd046d9a5c377f",
+        "semantic_sha256": "527dd8f17462ee54c3cd333b4e96c68d50c8cc773817c71db992ba973a062e06",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "86ae53834dd2bce54d2808ecb21228f122bfcda54d9f4400c42816e8a024f317",
+        "explain_sha256": "3804fab9457b0fff471629f622812e40477a1a2f3ca5a9b73531850a5faf6a82",
+        "translations_sha256": "883492addd5de10039003e667cca0d8ffc152e349708f68a101fae7f17811d34"
+      }
+    },
+    {
+      "name": "pl-experimental",
+      "legacy_path": "Ultimate Geography [PL] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "10abb7ad29318e8946904212175d19f66b9bb08f64b47a5e375c489c25d4e487",
+        "canonical_sha256": "77da9503a5f0fe3e16f9bdd49ff39442842a73939059c6c3a436649c09f31a7d",
+        "semantic_sha256": "04d0552026addb1fc885e3fc45f094398fd7c91ba2e532f03cc052ebde73d9aa",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "ffb4cd8cb1b2015934132d74a78222216795f01850f5dd4244040584b08629c0",
+        "canonical_sha256": "6005dd20bf3669853f6546fa82a60e109be6e7f3e5285d21b404f030d6e6c877",
+        "semantic_sha256": "04d0552026addb1fc885e3fc45f094398fd7c91ba2e532f03cc052ebde73d9aa",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "060e5eb67447e689e71f24a41f69856ab896c63f7cc3adbc87398aeae3e0ec1f",
+        "explain_sha256": "69ed00bc9350b2a656502f190c63e658b4e6b25cd6ea8c8ceba5f5cc86ffbfcb",
+        "translations_sha256": "8a1bc4a55a96f19e3f637aa807013b7a73c93687374e5a28f546d68e24fb1769"
+      }
+    },
+    {
+      "name": "pl-extended",
+      "legacy_path": "Ultimate Geography [PL] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "ec761556dfb19a51ba429f2c896051b810994cb964148e1512d7a9c41aeaceb3",
+        "canonical_sha256": "f47d8384161fe972136fe158eb2c2259a33dacbabb8f0e31f747d6f1ffb80e20",
+        "semantic_sha256": "1a6f9a1dc94bbab88e9ed06291f1966564ddf5d629ffbfbf4945e2ec2a1a2c7e",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "86ce4fb2bb3fad4bf4637c429caf7a0210c9798b8829f99c9d75508b518e2c34",
+        "canonical_sha256": "e6e742e8e0d9dc95c6e8aa158be1b30170377f98e6df03244abc8d0b716d4eac",
+        "semantic_sha256": "1a6f9a1dc94bbab88e9ed06291f1966564ddf5d629ffbfbf4945e2ec2a1a2c7e",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "d1ebf68b4807f41e7ebf9314fb2fe9cc101ec83727485236bc263af4a7778011",
+        "explain_sha256": "57a06841d5d670e0a63aa6ed00dbe1ff258f4c0bd6f07282ab3318e1428a9f11",
+        "translations_sha256": "abc4a642d811f204fcc18045e4a1bec797c8e900eb01b62f7633f6e53bf25340"
+      }
+    },
+    {
+      "name": "pl-standard",
+      "legacy_path": "Ultimate Geography [PL]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "298449adcd73ef2dbf10bfbed284cf288693cbecc6a19589e356e6a9ab59c50e",
+        "canonical_sha256": "af985e22e8d7656732d92346beebe50ad1d69fd68939f3bdc31f16eb5fdec535",
+        "semantic_sha256": "0b331bdc2450f3b84157a3a6c88511da2296d4d282313e49d57633b6488d016c",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "66be49c58cf94833c9ccbcd48d643da6c70b152ac531e61cc19e1f7e8db344ad",
+        "canonical_sha256": "274408fa87a88ca3f9292b46e51ff98f2735915ea37b4673dc0488c634b5934f",
+        "semantic_sha256": "0b331bdc2450f3b84157a3a6c88511da2296d4d282313e49d57633b6488d016c",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1018,
+      "artifacts": {
+        "compose_sha256": "3794d00bfac09e90b8e1d78a15b51f829a0d0f1590f06009eb7108653d12821a",
+        "explain_sha256": "4fc3173942c7a60a2930a933ab17830f22be0d5336a4dcc1863e949d8dfd55d9",
+        "translations_sha256": "af70aca6be7838e48434704156a7353cffbfda5cd3440520d59dce85efc6f2f8"
+      }
+    },
+    {
+      "name": "pt-experimental",
+      "legacy_path": "Ultimate Geography [PT] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "e68b539a23c27aa0bbfdbbeace4ffd57764e3e11f74fb8ff0a3419c7feaaab1d",
+        "canonical_sha256": "5d14fea9e65fca7d6b62a35cf909849e9cbcb9d29aa34c0ab1bb9196eade85e9",
+        "semantic_sha256": "1fd786938240f8ec24f9dc72c5fc94dfb69500128d05527dfd552c39366193ed",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "d554a7917d610f747d63ed7e5c4864c2b359857ea1e856fd95ac80c8a692d92c",
+        "canonical_sha256": "bdd4a8c54af46a76fc8c0f10fc72352d51eb23314eae0148f2c00ff6bda99a01",
+        "semantic_sha256": "1fd786938240f8ec24f9dc72c5fc94dfb69500128d05527dfd552c39366193ed",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1014,
+      "artifacts": {
+        "compose_sha256": "3f5c6d60932ae277836419f686ae9a95c0ead3442db7671a47f75444d3be35ac",
+        "explain_sha256": "8b67d892156bf7695614f921f7cc0fbf13e809f1dbe2bc00e923e733617f9947",
+        "translations_sha256": "a2a4f0aa991672507ad8f2641c5a975f427012c1033349e61c70cfd96aad89ab"
+      }
+    },
+    {
+      "name": "pt-extended",
+      "legacy_path": "Ultimate Geography [PT] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "6f2e557e288469e5a4b10a743a036efc9ae06dec191e923926f61f0bb35590a2",
+        "canonical_sha256": "1650a1b6933fcd0cb98c806d98b6a25e93bf9d505baa03016356e5c89d5893c7",
+        "semantic_sha256": "21c4fc514f7c2862370a22f8d6718d3d6ffe64c2301862c9d82a9ad3c3ac6174",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "c9bd0b72cd4bbeb06255fda6e73931822d9e9ce6fff2f78c98189a64fd5a9115",
+        "canonical_sha256": "3c82496aee7eee97fdb011299a81e4b071ce2032c9a7f11badda8a627863f14e",
+        "semantic_sha256": "21c4fc514f7c2862370a22f8d6718d3d6ffe64c2301862c9d82a9ad3c3ac6174",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1014,
+      "artifacts": {
+        "compose_sha256": "542c66747920d9b8734c445c2e4ee09b00701111ffbd90728d29e2b5594cd4f9",
+        "explain_sha256": "8fd66b19297583a8be731f6b0df361fb0a035540a86c8f777de776eda7b67268",
+        "translations_sha256": "1e704b335b61157675929b08b8164d829baca3ae0e84df974e2b0d9a21e3622f"
+      }
+    },
+    {
+      "name": "pt-standard",
+      "legacy_path": "Ultimate Geography [PT]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "43de3a2806a0d0b55edea8d390117cf7169d892e3e20ee517571a9c86a81893f",
+        "canonical_sha256": "37319de27286738388c140aa9bcf6d626c152142d1613d90613d5ea9a41a7217",
+        "semantic_sha256": "72cfd9b527a024b629032ec85a77d655d27755ad6fc177349f2b2b0bdf1181ad",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "e48b30acd5e0f86042a0a0d16b3e330b019685ddc0f5c65f72362dae4559569d",
+        "canonical_sha256": "dcdc4bd4c8466d7c152dc5e7a7545de85fc4b0df3b8aefe5157126e206935b1d",
+        "semantic_sha256": "72cfd9b527a024b629032ec85a77d655d27755ad6fc177349f2b2b0bdf1181ad",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1014,
+      "artifacts": {
+        "compose_sha256": "8067e0ceac89e663a7169bead544498270eafb923819b9b8f564c1981d9ad936",
+        "explain_sha256": "651a9a76cfdc23c62aa702a4453a3c9651d6ae94633589a69dbe9e63e5b1cb23",
+        "translations_sha256": "c76e77ab8aa2576379c066a7afa7f1a0dee18fc11c6253e5f092acedf9d0c0c9"
+      }
+    },
+    {
+      "name": "ru-experimental",
+      "legacy_path": "Ultimate Geography [RU] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "885a56f9e69d1c09e9966097db3bdb54fa3c7a0ee0ea9b46548309a2e647ec69",
+        "canonical_sha256": "aec608dfe989f69ac7a55f1620ee55a979909b9c21aae133ed648f5ed6b9ba24",
+        "semantic_sha256": "8d79ec16cece9c0d027cd621c0e2c1bbaacb6677c9e1d14329e1fb1e20ce3933",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "7465604017414cb7e77df1d7979d30f299931f45e8d791fa4f6df47618ca2e15",
+        "canonical_sha256": "c8949b50139f8d205e79f891430c7fd9597a955e173b2ac56b7d4da63af7497f",
+        "semantic_sha256": "8d79ec16cece9c0d027cd621c0e2c1bbaacb6677c9e1d14329e1fb1e20ce3933",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1015,
+      "artifacts": {
+        "compose_sha256": "e761378aa74c201bd1868cdabc4b07349582cade75c634dac7a404bd3a09e034",
+        "explain_sha256": "d229d2a6c8a14f3eca6b5ff7ba510359a9cecbff45f1f9383a368064b75a0a2c",
+        "translations_sha256": "6600abff810a130f9d56b37433921b4b5a9eea63144ffe86db8a1a886db5b968"
+      }
+    },
+    {
+      "name": "ru-extended",
+      "legacy_path": "Ultimate Geography [RU] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "2c8c5e62ad4b45ed2586fc6774b643a3ec0b4a21a144e12266357751263de52c",
+        "canonical_sha256": "c43aee8397c9d586fe28b997dd0d8f98de954d4ab92aff2483c19eb32e313475",
+        "semantic_sha256": "6d299d03c1736d565a870a221f8a87d48ef8c5ca5513833f9cc4cfc16066c1a6",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "50b6fe3d55b7bf8629de89551058c550be0439205de07b32b66869d273124e69",
+        "canonical_sha256": "061bc9742889aee40e2d6467bbe9c07a2773be17f61a6188631d9dc022964658",
+        "semantic_sha256": "6d299d03c1736d565a870a221f8a87d48ef8c5ca5513833f9cc4cfc16066c1a6",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1015,
+      "artifacts": {
+        "compose_sha256": "523e195a0f5fd28a71e2ef1c27eaa837be732c695ef542f2933eae397fdc28cd",
+        "explain_sha256": "b20f977a9e6ecd0ff77944d26640b93af7552446aaed49170baa44eb0d23c54c",
+        "translations_sha256": "50593db3b8c643baef19442949786bc23f239094af65918a37761df915dc0a2e"
+      }
+    },
+    {
+      "name": "ru-standard",
+      "legacy_path": "Ultimate Geography [RU]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "c12b640e61f28e8def0333a528f91326bc45c5db44594379999c7d9184bf94fd",
+        "canonical_sha256": "6f974bcf96a6cb82e1fc82b47087f8b51ac2acc38629c6ab9e586ff1802b86ed",
+        "semantic_sha256": "2a54c0d0f32e88b3a7feb48bc6020af25772f6023998a482712e06f9c104a3c9",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "f3f72aadb5b4683dc95b8119b0b56fb78105b0e4c52911779ffe5b953d306fee",
+        "canonical_sha256": "9f40d5c7e1d79842ef0860415b3dfc094745e1240eaad64461ab5aa3ad517916",
+        "semantic_sha256": "2a54c0d0f32e88b3a7feb48bc6020af25772f6023998a482712e06f9c104a3c9",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1015,
+      "artifacts": {
+        "compose_sha256": "d49f5dc9193d9c67247b08b0163f4c10c1faefcf452b0867b9e99ede8d52e130",
+        "explain_sha256": "7c055722f2266af1fa377cd1becb7d1b59a5912c23790b1fe648d0f73c1b3c61",
+        "translations_sha256": "a4cc5f606f93ff87cfb9a53bb1b868dacb59a321bc5197211af188aa12b64371"
+      }
+    },
+    {
+      "name": "sv-experimental",
+      "legacy_path": "Ultimate Geography [SV] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "6858eef22956d76417d81a04b2680c02fad5adb90eb59a97d71a6065ae97e4fc",
+        "canonical_sha256": "d66c0e18711d88b2835d441e49e3748de4fcdb2af44e1526747da2b0d603f38f",
+        "semantic_sha256": "d3e713bda16631f7cc8562498e467cc3de33b4b9048d49ee1cdbf5e4fb39c174",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "ef7e8792a2350af743f21150fafe8e3f146e0d7cd3d2c05f2fd8ad7fd7e9d7ab",
+        "canonical_sha256": "cb30ba2cf0ac50fe3fd0ccf74a24040541411eca739e2c2a3b9a16285b981b24",
+        "semantic_sha256": "d3e713bda16631f7cc8562498e467cc3de33b4b9048d49ee1cdbf5e4fb39c174",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1026,
+      "artifacts": {
+        "compose_sha256": "e0f53db7b3f9b929ac49336ff8cd91ed9183f2fbb43bbe42630a50a75bb9eec8",
+        "explain_sha256": "8c59f7e489df244a6df06121b00652028aef2e3f680ff02feee09cf83193d1b8",
+        "translations_sha256": "e8c74bd5607f3739cf21ea46e75dc4cfb33ec2b72fc4d8e0258f18def72c843a"
+      }
+    },
+    {
+      "name": "sv-extended",
+      "legacy_path": "Ultimate Geography [SV] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "57ce80a68f3abca6e8581c88ed19b04111332102dd87710534ed0f6c4fbfa8f7",
+        "canonical_sha256": "b1555df28f22a791d8797063b8055de5f7c19ddfcf2a5bb08b2aba61a1db4434",
+        "semantic_sha256": "00bf4174a8a59f26098a950db1ad0f6e192ca3fb6f1e135e667cc28a7636880b",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "c87c4c3c90e6adbad22c602b65b0e99bd89975fac569060fd9f0ea57598c0c8f",
+        "canonical_sha256": "87482662a07dd64b3cf398d50488fc9e8591e83b4bb8fea3720580ba152a1fa8",
+        "semantic_sha256": "00bf4174a8a59f26098a950db1ad0f6e192ca3fb6f1e135e667cc28a7636880b",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1026,
+      "artifacts": {
+        "compose_sha256": "f6eb32135eb81c697fd9a49bb2e2e56759199b58e09864f850f272c2640ab782",
+        "explain_sha256": "4829bd4c1473b225fb4cecd7f8219ac082620c27c3d904366f8ffeb6bd2f940f",
+        "translations_sha256": "2f5c9de1515532eb693eb46e1e016491379a2352fe5e8fefbd080b2ef0c07a1b"
+      }
+    },
+    {
+      "name": "sv-standard",
+      "legacy_path": "Ultimate Geography [SV]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "abe56d9aaf392c94811b4e807bb85d593d6f7ec1fd35d9b5efa2f774e6330733",
+        "canonical_sha256": "870d109aa08535733a056d06b9e00f573292ee5ab093318ec99f8dc2d63a556a",
+        "semantic_sha256": "83ff89ff349193d9bd14c3bf91e3a6b7200644c1b14bb282ee2ebe4c01d963ee",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "bf71ab07abd47a332a19fe8427a0ba7362dcd8ec659bfbf08f020f58019a87e4",
+        "canonical_sha256": "6dd3d81e33cdb8feed9b5698cc602a1db83f5fb55c896925a5c3572fb2a748ca",
+        "semantic_sha256": "83ff89ff349193d9bd14c3bf91e3a6b7200644c1b14bb282ee2ebe4c01d963ee",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1026,
+      "artifacts": {
+        "compose_sha256": "c57038ac6909d6ffb5f803324688d4d68b6d55ef620e13dfba6a3a15a29fb9a2",
+        "explain_sha256": "2eb484f8834ea95400c534a50f6f1ca230460aaeebfa3abf57d8005d341e13cc",
+        "translations_sha256": "56bfc92b75f896b3c15b18fc69925b50d1048f6c80f030600a8e77108c84d762"
+      }
+    },
+    {
+      "name": "zh-experimental",
+      "legacy_path": "Ultimate Geography [ZH] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "3c972c03461e83c348ef2150b7bdb32b621868cfb075ce7de0478a562ff29fc2",
+        "canonical_sha256": "888c2dfb28bce8747c8adecb5c511c8f062191f70529adf4ba72290c3a4f6d23",
+        "semantic_sha256": "5cf9bb72217a02ace8de42b4bf4d561fefabb1128168c4aa320051c052097180",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "50a61fc1a6561fb2c5292629646e8c1daa41c023ccd27ef679f5f34abd6d3b30",
+        "canonical_sha256": "fc3c93691c3e7cdb8215878441f20bf0cc8cba5f4205b523cb31a5dcfc4d424f",
+        "semantic_sha256": "5cf9bb72217a02ace8de42b4bf4d561fefabb1128168c4aa320051c052097180",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1014,
+      "artifacts": {
+        "compose_sha256": "dcf687692788f68564499dc3ec85101f2df7f6f22c831de9788b7426e152ce05",
+        "explain_sha256": "3c310129a17296fbcd426f2c4ef94e0df57e0b7abf7b61ac00cb0782887e8143",
+        "translations_sha256": "f1b8265e850b32296fae9fc8faf9aa47894ea3d389d0c423d31c98a971bb6cd4"
+      }
+    },
+    {
+      "name": "zh-extended",
+      "legacy_path": "Ultimate Geography [ZH] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "bf4b282f0029b11602d9ec0c11372cedb9f1cc7a89103b51f8f4c2055c68cea5",
+        "canonical_sha256": "61f74935a32c24836def3b7b5be08464e6e33f82b7203b56121584c433b815cc",
+        "semantic_sha256": "dbe79474df58b22c3c9e3469aba2801890943752f207e66d11b78044ab81f308",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "a20eb8d2ee8fec507cbf181f3eb3590318e23127e2f3668563a4209d1f45f2b5",
+        "canonical_sha256": "c8c721391291d81318d38485df61db97abb5d10b03958bda508b5b3f543b3714",
+        "semantic_sha256": "dbe79474df58b22c3c9e3469aba2801890943752f207e66d11b78044ab81f308",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1014,
+      "artifacts": {
+        "compose_sha256": "5bf2e9b594439d7a1ee07972198be03744506d00a5f7bb2dd797cb9971c14a33",
+        "explain_sha256": "46b21914848946600285c9839e850f0004646736517346b52b10c6ab8c9cd4c3",
+        "translations_sha256": "a62e09c9432bedd26777148a551c61daeae0186c9a8b838951a9fa0acdfdaa1b"
+      }
+    },
+    {
+      "name": "zh-standard",
+      "legacy_path": "Ultimate Geography [ZH]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "ff70fea7587d55c8e0559604c8d2f6d9044ebe367a8a4ab2eb3db6814b7b60d2",
+        "canonical_sha256": "7116c51a4e558980e89f3ecdd7123d2a9f526cd0daa1d41025334a504fe54dab",
+        "semantic_sha256": "a4db6de8db64e698c2687a63105bee4f9f90e6bbde21a0f2ed5b8fa9115f70a4",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "f97e3b73e0d33b9be2717c3bb2170ae806449ed01151064d28ae4ebae19c3637",
+        "canonical_sha256": "b006a27ca7377ba45dcc929c981552a9432cb74fd74a628a1d53ba138805d046",
+        "semantic_sha256": "a4db6de8db64e698c2687a63105bee4f9f90e6bbde21a0f2ed5b8fa9115f70a4",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1014,
+      "artifacts": {
+        "compose_sha256": "2adc033b95fa30cce216848307584e0cda6bdea7ed8873185d57bbed68ac244f",
+        "explain_sha256": "6394a60432f8337e4bc3a87bc63b40c6604dc4eabf08b2519af55612068502be",
+        "translations_sha256": "81a2a361586560007a953448f59e7b4c808996565502d54a60d64d41aeca7ed3"
+      }
+    },
+    {
+      "name": "zh-tw-experimental",
+      "legacy_path": "Ultimate Geography [ZH-TW] [Experimental]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 555,
+      "legacy": {
+        "deck_sha256": "11ea8dbe8d393f2220788c66660b9c730372eec5ad5ca70facd4874bcc321947",
+        "canonical_sha256": "4bd903155f62cb1ac42762f03f4a9f907795792ce4450adbca97d92aa6b594b6",
+        "semantic_sha256": "69868d7d0bef273007609d03d51ce49e5ba29f2b02d8fe441ce9f8ef436a2a26",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "rust": {
+        "deck_sha256": "e78f94741b5ac8f026db5663640ac8b4bb1d5582f119da05adaa7eff349b1649",
+        "canonical_sha256": "6fbcce9733ae0b4f108eb9d828d003ff05c3a4eada8800b7684a790fe7614c8d",
+        "semantic_sha256": "69868d7d0bef273007609d03d51ce49e5ba29f2b02d8fe441ce9f8ef436a2a26",
+        "media_tree_sha256": "a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "experimental",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "61f7a3bbd0f447d385007ff04b84767c6f0b9210c8f8d2633fa0216f753f8eb5",
+        "explain_sha256": "8c6d2ada8a407b99f6f34a6fe6bd851e975224a73255acd25e06819f4f9def86",
+        "translations_sha256": "df83f320ad8563468065a9cdc083aa7ed407be7a96ec4a4909d8edf7ddf2b5a6"
+      }
+    },
+    {
+      "name": "zh-tw-extended",
+      "legacy_path": "Ultimate Geography [ZH-TW] [Extended]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "8307e99ec0dd215bde6b6464e4554dd05f70dd36051f21b0ca11648636b12b2e",
+        "canonical_sha256": "1a1fc0d60eb15e035165d665c22d6fb6b3913cfe34049328d551574e6363e59c",
+        "semantic_sha256": "2a284bf6dec106f74b97b2b6da3630246e41cc8d0a3dc0ffadc9bdac179454fe",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "9c917b688e52f662194a3ad9cceead77b4a7cba92158d11adff569044b938724",
+        "canonical_sha256": "085184517869450c5195af67bc2d33ae2bb214b9698674aaf92b66ab5817b5a9",
+        "semantic_sha256": "2a284bf6dec106f74b97b2b6da3630246e41cc8d0a3dc0ffadc9bdac179454fe",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "044db56be8c1a21d9072811afdf7959c8202c8e30d706b4b47eb4f4539728f5f",
+        "explain_sha256": "a8b58265b23295287a9a3ffac2c8a1d1741946b8a6f63bbb99de0e0e65078c32",
+        "translations_sha256": "3c1bb17008b9e4a510ad3e37c3db0825e7176996815ce5d99db383921074adb5"
+      }
+    },
+    {
+      "name": "zh-tw-standard",
+      "legacy_path": "Ultimate Geography [ZH-TW]",
+      "notes": 323,
+      "note_models": 1,
+      "media_count": 550,
+      "legacy": {
+        "deck_sha256": "ee0ca400199579f380aba998f4edb0b3e8046f444ff656d150fdf5cc62ff5932",
+        "canonical_sha256": "b6f70c8e9287fe4fb1160e5114986bf2ef58a78d3f3dbd40b75452f0b419a3ba",
+        "semantic_sha256": "9e21cf3bc51f2e7f84f8c3281f1ae15ab75f8a48592089b801dd69dde94d6cab",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "rust": {
+        "deck_sha256": "0f977876dca421aa0573ad359eaa6d9121dc089d662f60f023f0228117bc751f",
+        "canonical_sha256": "9b6a0a918e3afef9ca7861f195c6bb86bd18db4cfc1840d659837e64e2247bff",
+        "semantic_sha256": "9e21cf3bc51f2e7f84f8c3281f1ae15ab75f8a48592089b801dd69dde94d6cab",
+        "media_tree_sha256": "be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95"
+      },
+      "semantic_equal": true,
+      "media_equal": true,
+      "byte_equal": false,
+      "serializer_only": true,
+      "json_differences": [],
+      "media_differences": {
+        "missing": [],
+        "extra": [],
+        "changed": []
+      },
+      "media_family": "standard",
+      "counts_equal": true,
+      "csv_translation_units": 1012,
+      "artifacts": {
+        "compose_sha256": "0a2227ba0473ba8796fa86212af06c6feafda392913298046653e5a8a939113d",
+        "explain_sha256": "b15771677f46d736ef1f06f7d0fd99f850f1534be68b39e5872ac8cbdb73d7b6",
+        "translations_sha256": "57d2945ff71c2c884317d435e61dfa1e446c0d452c41a95106c8adffd2609151"
+      }
+    }
+  ]
+}

--- a/migration/brainbrew/full-parity.md
+++ b/migration/brainbrew/full-parity.md
@@ -1,0 +1,72 @@
+# Full production parity certification
+
+Result: **PASS** — 48 targets (16 Standard, 16 Extended, 16 Experimental).
+
+## Toolchain and commands
+
+- Legacy: Python Brain Brew `0.3.11`; `pipenv run build` and `pipenv run build_experimental`.
+- Rust: Brain Brew `1.0.0-alpha.8` at `1e56a90a42be2522431cd678dfd81617eb4214a6`.
+- Rust verification: `brainbrew verify --manifest brainbrew.yaml --all-targets --media-root build/brainbrew-media/standard`, plus validate, compose, per-target verify, explain, translations, and CrowdAnki export for each discovered target.
+- Comparison normalizes only JSON object keys, top-level notes by GUID, and `media_files` by filename; every other array and all media names/bytes remain strict.
+- This package has no federated dependencies, so no federation lock is required; explain reports record source fingerprints.
+
+## Target evidence
+
+| Target | Semantic SHA-256 | Media tree SHA-256 | Media | Raw JSON bytes | CSV translation units |
+|---|---|---|---:|---|---:|
+| `cs-experimental` | `b462d90848b5c399ac5dec38127dfedcaca1032f46d800d8643c92c923d03652` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1013 |
+| `cs-extended` | `37bbd431088eab6800a8f1a425de1f59dc38fd983e0ce97dc840b9b9f3ea51c4` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1013 |
+| `cs-standard` | `b12232535af9f7716322613d4d6ef8a7c24dc5a9d5137d7378e62f30b8919fbf` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1013 |
+| `da-experimental` | `f2f954ba1a00a8727b967e2f6432cf39f3a305a4d74828d674fe3f087ffc831a` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1018 |
+| `da-extended` | `e78888ef8d5615196fb92b1b36720e07a3df9c0857ab182cf08854b62ddf9037` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1018 |
+| `da-standard` | `d810dfb3d843759396f1baf27f97564e1ee8aebb6d19800dc254c0a64295a0a6` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1018 |
+| `de-experimental` | `0275c43ebe4167d452e99ad8325e955c2b17c84e314e818bcdb6c18103fc2e63` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1028 |
+| `de-extended` | `8ef41fdba1a4e1418940784a2e87fe4443c9624faecfdebfb0b4b28d7b7cef0c` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1028 |
+| `de-standard` | `9a396d0012403123d8be062bd859b744a85715e8d204dc4e396eb092bdd42d58` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1028 |
+| `en-experimental` | `d946192704bc21ee0c6d02c9c0fed8825be707520e5674f2edc66ac0c6731a5f` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 0 |
+| `en-extended` | `26f550ddfa7271c02fee16d69cd4a6dd7d18c53c5c027d7ce5ba13952dae9c6e` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 0 |
+| `en-standard` | `de48fb4df5846ff9250cf3ac3e62cd8f2073b862942cf3389a4cdf8a2ea3cfa4` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 0 |
+| `es-experimental` | `895d43f55f0c382676a0554911cd7f896fe58c1c228acc76936dacfa60bf1b00` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1012 |
+| `es-extended` | `ff324f6ee1ff839194d2854a01b8ce383c5a7c115796dcf673540891d5ec3fdc` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+| `es-standard` | `6934b15ebcc78d62e798b81e7c9a024a01aeeebd97f6f61d1bb315256d78fd81` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+| `fr-experimental` | `89c411a65ae89873b09e42116e54e476c3d52795de362ba4f2983d2a544d949b` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1012 |
+| `fr-extended` | `7b38404f4787d941297197b9b753a656af8dbac2ecb9441bffae1939640506d1` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+| `fr-standard` | `5be49194a55c77d169c8c9396979f6d8aae3817e2479dd0479fcca5ad280769f` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+| `he-experimental` | `8175b2d14adbcb8b80f5027d4d31f62ec84282a7ec8ba4910348e9ed259a7f9d` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1015 |
+| `he-extended` | `6f4a3e9d5e6e1ecfe116cc3c4a78d85117e295f96fd641e8a38519bf5ab694fe` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1015 |
+| `he-standard` | `e4b0ba607ba7bbfb97c255dadd973e4b93dd47593b77d5bffdfcbaf5aa29ac99` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1015 |
+| `it-experimental` | `ffbac2255deebedf21e47cfa0117cf14b2f0224a984e96034077732d6d976e39` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1012 |
+| `it-extended` | `12550f8282152c0396046b4b3d96b0750d4a2f3d1fcf1a72314a53f71c4f4847` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+| `it-standard` | `6cbb955a0f2824e51dd74e9da345de521cff16d47e128047c4aa111b64d661cb` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+| `nb-experimental` | `7d7ac4de5a5e359e89662417a6eab99d952e11e609b229c71740ed7bac1e0080` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1029 |
+| `nb-extended` | `ba5c8e3abb5ec2e5677ce834c428b7f1686e9ac8f06f58c94c7e08321cc9fb52` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1029 |
+| `nb-standard` | `353c36f5d5c57130169d0eac8e0ae06d118fd9ac861d94ffb406a2053a5336f8` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1029 |
+| `nl-experimental` | `ae2482626eff63f5b574f086113550212d91a24e459ac7d3dc595d51d8399f8d` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1018 |
+| `nl-extended` | `fba42d1843f923bf599ff3bcfcfdf2edd63008d57dcd42aae623f0a8b8b86727` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1018 |
+| `nl-standard` | `527dd8f17462ee54c3cd333b4e96c68d50c8cc773817c71db992ba973a062e06` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1018 |
+| `pl-experimental` | `04d0552026addb1fc885e3fc45f094398fd7c91ba2e532f03cc052ebde73d9aa` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1018 |
+| `pl-extended` | `1a6f9a1dc94bbab88e9ed06291f1966564ddf5d629ffbfbf4945e2ec2a1a2c7e` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1018 |
+| `pl-standard` | `0b331bdc2450f3b84157a3a6c88511da2296d4d282313e49d57633b6488d016c` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1018 |
+| `pt-experimental` | `1fd786938240f8ec24f9dc72c5fc94dfb69500128d05527dfd552c39366193ed` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1014 |
+| `pt-extended` | `21c4fc514f7c2862370a22f8d6718d3d6ffe64c2301862c9d82a9ad3c3ac6174` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1014 |
+| `pt-standard` | `72cfd9b527a024b629032ec85a77d655d27755ad6fc177349f2b2b0bdf1181ad` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1014 |
+| `ru-experimental` | `8d79ec16cece9c0d027cd621c0e2c1bbaacb6677c9e1d14329e1fb1e20ce3933` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1015 |
+| `ru-extended` | `6d299d03c1736d565a870a221f8a87d48ef8c5ca5513833f9cc4cfc16066c1a6` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1015 |
+| `ru-standard` | `2a54c0d0f32e88b3a7feb48bc6020af25772f6023998a482712e06f9c104a3c9` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1015 |
+| `sv-experimental` | `d3e713bda16631f7cc8562498e467cc3de33b4b9048d49ee1cdbf5e4fb39c174` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1026 |
+| `sv-extended` | `00bf4174a8a59f26098a950db1ad0f6e192ca3fb6f1e135e667cc28a7636880b` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1026 |
+| `sv-standard` | `83ff89ff349193d9bd14c3bf91e3a6b7200644c1b14bb282ee2ebe4c01d963ee` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1026 |
+| `zh-experimental` | `5cf9bb72217a02ace8de42b4bf4d561fefabb1128168c4aa320051c052097180` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1014 |
+| `zh-extended` | `dbe79474df58b22c3c9e3469aba2801890943752f207e66d11b78044ab81f308` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1014 |
+| `zh-standard` | `a4db6de8db64e698c2687a63105bee4f9f90e6bbde21a0f2ed5b8fa9115f70a4` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1014 |
+| `zh-tw-experimental` | `69868d7d0bef273007609d03d51ce49e5ba29f2b02d8fe441ce9f8ef436a2a26` | `a7f8acc1b531c6e777ea8f81a2c445cfc278c2d984a6dcc1424fad94de093df8` | 555 | serializer-only difference | 1012 |
+| `zh-tw-extended` | `2a284bf6dec106f74b97b2b6da3630246e41cc8d0a3dc0ffadc9bdac179454fe` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+| `zh-tw-standard` | `9e21cf3bc51f2e7f84f8c3281f1ae15ab75f8a48592089b801dd69dde94d6cab` | `be1ec8784102046ccefa0874d7d3a7e7feaff94372eedebd5ec727b920497d95` | 550 | serializer-only difference | 1012 |
+
+Every row has semantic JSON equality and exact media filename/byte equality. Raw JSON byte differences are serializer formatting/order only and are not used to excuse content differences.
+
+## Ownership and Workbench evidence
+
+All 323 production notes and localized CSV fields remain CSV-owned and read-only; identity validation proves 323 unique stable note IDs and exact typed-media references while `main.csv` remains byte-identical to the legacy source.
+
+No Hardcore/federation targets, translation corrections, editorial changes, CSV write-back, generated note YAML, or generic transformation layer are included.

--- a/migration/brainbrew/test_certify_full_parity.py
+++ b/migration/brainbrew/test_certify_full_parity.py
@@ -1,0 +1,73 @@
+import copy
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from migration.brainbrew.certify_full_parity import (
+    expected_targets,
+    parity_record,
+    target_coordinates,
+    validate_target_names,
+)
+
+
+class CertifyFullParityTest(unittest.TestCase):
+    def test_exact_matrix_and_legacy_coordinates(self):
+        targets = expected_targets()
+        self.assertEqual(len(targets), 48)
+        self.assertEqual(
+            target_coordinates("zh-tw-experimental"),
+            ("Ultimate Geography [ZH-TW] [Experimental]", "experimental"),
+        )
+        self.assertEqual(
+            target_coordinates("fr-extended"),
+            ("Ultimate Geography [FR] [Extended]", "standard"),
+        )
+        validate_target_names(targets)
+        with self.assertRaisesRegex(ValueError, "missing targets: en-standard"):
+            validate_target_names(targets - {"en-standard"})
+        with self.assertRaisesRegex(ValueError, "unexpected targets: en-hardcore"):
+            validate_target_names(targets | {"en-hardcore"})
+
+    def test_parity_record_accepts_serializer_only_changes_and_rejects_content(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            deck = {
+                "crowdanki_uuid": "deck",
+                "media_files": ["flag.svg"],
+                "note_models": [{"crowdanki_uuid": "model", "flds": [], "tmpls": []}],
+                "notes": [{"guid": "guid", "fields": ["France"], "tags": []}],
+            }
+            self.write_target(root / "legacy", deck)
+            self.write_target(root / "candidate", dict(reversed(list(deck.items()))), compact=True)
+
+            record = parity_record("en-standard", root / "legacy", root / "candidate")
+            self.assertTrue(record["semantic_equal"])
+            self.assertTrue(record["media_equal"])
+            self.assertFalse(record["byte_equal"])
+            self.assertTrue(record["serializer_only"])
+
+            changed = copy.deepcopy(deck)
+            changed["notes"][0]["fields"][0] = "Germany"
+            self.write_target(root / "candidate", changed)
+            record = parity_record("en-standard", root / "legacy", root / "candidate")
+            self.assertFalse(record["semantic_equal"])
+            self.assertFalse(record["serializer_only"])
+
+    @staticmethod
+    def write_target(root, deck, compact=False):
+        if root.exists():
+            shutil.rmtree(root)
+        root.mkdir(parents=True)
+        (root / "deck.json").write_text(
+            json.dumps(deck, separators=(",", ":")) if compact else json.dumps(deck, indent=2)
+        )
+        media = root / "media"
+        media.mkdir()
+        (media / "flag.svg").write_bytes(b"same")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Certify full dual-pipeline parity

**Stack:** 10 of 14  
**Bookmark:** `brainbrew/09-full-parity`  
**Depends on:** `brainbrew/08-experimental-localized`

## Summary

- Build all 48 targets independently through Python Brain Brew and Rust Brain Brew from the same checkout.
- Add a fail-closed live certification gate and commit the recorded PASS evidence.
- Compare semantic CrowdAnki data and exact media names/bytes.

## Comparison contract

Normalization is limited to JSON object-key order, top-level notes by GUID, and `media_files` by filename. Fields, tags, templates, descriptions, RTL metadata, all other arrays, media filenames, and media bytes remain strict.

## Validation

- 48/48 targets pass semantic and media equality.
- Every target has 323 notes.
- 32 Standard/Extended targets have 550 media files.
- 16 Experimental targets have 555 media files.
- Any mismatch reports a concrete JSON or media path and fails the gate.

The committed JSON/Markdown records this reviewed run. CI independently reruns live dual-pipeline certification; it does not require regenerated report bytes to match the committed report.
