### PR TITLE
Split combined card templates

### DIFF
--- a/experimental.yaml
+++ b/experimental.yaml
@@ -28,16 +28,16 @@ note_types:
         insert_after: template.capital-country
         template:
           name: Country - Flag
-          question_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#question'
-          answer_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#answer'
+          question_format: !include templates/ultimate-geography/country-flag/question.html
+          answer_format: !include templates/ultimate-geography/country-flag/answer.html
           adapter_ids: {}
       template.country-map:
         intent: add
         insert_after: template.flag-country
         template:
           name: Country - Map
-          question_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__] [Experimental].html#question'
-          answer_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__] [Experimental].html#answer'
+          question_format: !include templates/ultimate-geography/experimental/country-map/question.html
+          answer_format: !include templates/ultimate-geography/experimental/country-map/answer.html
           adapter_ids: {}
 media:
   media.interactive-map-config-js:

--- a/extended.yaml
+++ b/extended.yaml
@@ -15,14 +15,14 @@ note_types:
         insert_after: template.capital-country
         template:
           name: Country - Flag
-          question_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#question'
-          answer_format: !include 'src/note_models/templates/base/Country - Flag [__LANGUAGE_CODE__].html#answer'
+          question_format: !include templates/ultimate-geography/country-flag/question.html
+          answer_format: !include templates/ultimate-geography/country-flag/answer.html
           adapter_ids: {}
       template.country-map:
         intent: add
         insert_after: template.flag-country
         template:
           name: Country - Map
-          question_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__].html#question'
-          answer_format: !include 'src/note_models/templates/base/Country - Map [__LANGUAGE_CODE__].html#answer'
+          question_format: !include templates/ultimate-geography/country-map/question.html
+          answer_format: !include templates/ultimate-geography/country-map/answer.html
           adapter_ids: {}

--- a/note-types.yaml
+++ b/note-types.yaml
@@ -53,23 +53,23 @@ note-type.ultimate-geography:
   card_templates:
     template.country-capital:
       name: Country - Capital
-      question_format: !include 'src/note_models/templates/base/Country - Capital [__LANGUAGE_CODE__].html#question'
-      answer_format: !include 'src/note_models/templates/base/Country - Capital [__LANGUAGE_CODE__].html#answer'
+      question_format: !include templates/ultimate-geography/country-capital/question.html
+      answer_format: !include templates/ultimate-geography/country-capital/answer.html
       adapter_ids: {}
     template.capital-country:
       name: Capital - Country
-      question_format: !include 'src/note_models/templates/base/Capital - Country [__LANGUAGE_CODE__].html#question'
-      answer_format: !include 'src/note_models/templates/base/Capital - Country [__LANGUAGE_CODE__].html#answer'
+      question_format: !include templates/ultimate-geography/capital-country/question.html
+      answer_format: !include templates/ultimate-geography/capital-country/answer.html
       adapter_ids: {}
     template.flag-country:
       name: Flag - Country
-      question_format: !include 'src/note_models/templates/base/Flag - Country [__LANGUAGE_CODE__].html#question'
-      answer_format: !include 'src/note_models/templates/base/Flag - Country [__LANGUAGE_CODE__].html#answer'
+      question_format: !include templates/ultimate-geography/flag-country/question.html
+      answer_format: !include templates/ultimate-geography/flag-country/answer.html
       adapter_ids: {}
     template.map-country:
       name: Map - Country
-      question_format: !include 'src/note_models/templates/base/Map - Country [__LANGUAGE_CODE__].html#question'
-      answer_format: !include 'src/note_models/templates/base/Map - Country [__LANGUAGE_CODE__].html#answer'
+      question_format: !include templates/ultimate-geography/map-country/question.html
+      answer_format: !include templates/ultimate-geography/map-country/answer.html
       adapter_ids: {}
   styling: !include src/note_models/style.css
   adapter_ids:

--- a/templates/ultimate-geography/capital-country/answer.html
+++ b/templates/ultimate-geography/capital-country/answer.html
@@ -1,18 +1,4 @@
 <div dir="${text.direction}">
-{{#Capital}}
-  <div class="value value--top">?</div>
-
-  <hr>
-
-  <div class="type">${label.capital}</div>
-  <div class="value">{{Capital}}</div>
-  {{#Capital hint}}<div class="info">${label.capital-hint}</div>{{/Capital hint}}
-{{/Capital}}
-</div>
-
---
-
-<div dir="${text.direction}">
 <div id=answer class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 

--- a/templates/ultimate-geography/capital-country/question.html
+++ b/templates/ultimate-geography/capital-country/question.html
@@ -1,0 +1,11 @@
+<div dir="${text.direction}">
+{{#Capital}}
+  <div class="value value--top">?</div>
+
+  <hr>
+
+  <div class="type">${label.capital}</div>
+  <div class="value">{{Capital}}</div>
+  {{#Capital hint}}<div class="info">${label.capital-hint}</div>{{/Capital hint}}
+{{/Capital}}
+</div>

--- a/templates/ultimate-geography/country-capital/answer.html
+++ b/templates/ultimate-geography/country-capital/answer.html
@@ -1,18 +1,4 @@
 <div dir="${text.direction}">
-{{#Capital}}
-  <div class="value value--top">{{Country}}</div>
-  {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
-
-  <hr>
-
-  <div class="type">${label.capital}</div>
-  <div class="value">?</div>
-{{/Capital}}
-</div>
-
---
-
-<div dir="${text.direction}">
 <div class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 

--- a/templates/ultimate-geography/country-capital/question.html
+++ b/templates/ultimate-geography/country-capital/question.html
@@ -1,0 +1,11 @@
+<div dir="${text.direction}">
+{{#Capital}}
+  <div class="value value--top">{{Country}}</div>
+  {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
+
+  <hr>
+
+  <div class="type">${label.capital}</div>
+  <div class="value">?</div>
+{{/Capital}}
+</div>

--- a/templates/ultimate-geography/country-flag/answer.html
+++ b/templates/ultimate-geography/country-flag/answer.html
@@ -1,21 +1,8 @@
 <div dir="${text.direction}">
-{{#Flag}}
-  <div class="value value--top">?</div>
-
-  <hr>
-
-  <div class="type">${label.flag}</div>
-  <div class="value value--image value--front">{{Flag}}</div>
-{{/Flag}}
-</div>
-
---
-
-<div dir="${text.direction}">
-<div id=answer class="value value--top">{{Country}}</div>
+<div class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 
-<hr>
+<hr id=answer>
 
 <div class="type">${label.flag}</div>
 <div class="value value--image value--back">{{Flag}}</div>

--- a/templates/ultimate-geography/country-flag/question.html
+++ b/templates/ultimate-geography/country-flag/question.html
@@ -19,16 +19,3 @@
   </div>
 {{/Flag}}
 </div>
-
---
-
-<div dir="${text.direction}">
-<div class="value value--top">{{Country}}</div>
-{{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
-
-<hr id=answer>
-
-<div class="type">${label.flag}</div>
-<div class="value value--image value--back">{{Flag}}</div>
-{{#Flag similarity}}<div class="info">${sentence.flag-similar}</div>{{/Flag similarity}}
-</div>

--- a/templates/ultimate-geography/country-map/answer.html
+++ b/templates/ultimate-geography/country-map/answer.html
@@ -1,0 +1,9 @@
+<div dir="${text.direction}">
+<div class="value value--top">{{Country}}</div>
+{{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
+
+<hr id=answer>
+
+<div class="type">${label.location}</div>
+<div class="value value--image">{{Map}}</div>
+</div>

--- a/templates/ultimate-geography/country-map/question.html
+++ b/templates/ultimate-geography/country-map/question.html
@@ -18,15 +18,3 @@
   </div>
 {{/Map}}
 </div>
-
---
-
-<div dir="${text.direction}">
-<div class="value value--top">{{Country}}</div>
-{{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
-
-<hr id=answer>
-
-<div class="type">${label.location}</div>
-<div class="value value--image">{{Map}}</div>
-</div>

--- a/templates/ultimate-geography/experimental/country-map/answer.html
+++ b/templates/ultimate-geography/experimental/country-map/answer.html
@@ -1,0 +1,16 @@
+<div dir="${text.direction}">
+<div class="value value--top">{{Country}}</div>
+{{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
+
+<hr id=answer>
+
+<div class="type">${label.location}</div>
+<div id="map" class="value value--map" style="display: none"></div>
+<div class="value value--image">{{Map}}</div>
+</div>
+
+<script src="_ug-jsvectormap.js"></script>
+<script src="_ug-world.js"></script>
+<script src="_ug-interactive_map_config.js"></script>
+<script src="_ug-interactive_map_init.js"
+        data-card-side="answer" data-region-code="{{Region code}}"></script>

--- a/templates/ultimate-geography/experimental/country-map/question.html
+++ b/templates/ultimate-geography/experimental/country-map/question.html
@@ -45,22 +45,3 @@
 <script src="_ug-interactive_map_config.js"></script>
 <script src="_ug-interactive_map_init.js"
         data-card-side="question" data-region-code="{{Region code}}"></script>
-
---
-
-<div dir="${text.direction}">
-<div class="value value--top">{{Country}}</div>
-{{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
-
-<hr id=answer>
-
-<div class="type">${label.location}</div>
-<div id="map" class="value value--map" style="display: none"></div>
-<div class="value value--image">{{Map}}</div>
-</div>
-
-<script src="_ug-jsvectormap.js"></script>
-<script src="_ug-world.js"></script>
-<script src="_ug-interactive_map_config.js"></script>
-<script src="_ug-interactive_map_init.js"
-        data-card-side="answer" data-region-code="{{Region code}}"></script>

--- a/templates/ultimate-geography/flag-country/answer.html
+++ b/templates/ultimate-geography/flag-country/answer.html
@@ -1,0 +1,10 @@
+<div dir="${text.direction}">
+<div id=answer class="value value--top">{{Country}}</div>
+{{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
+
+<hr>
+
+<div class="type">${label.flag}</div>
+<div class="value value--image value--back">{{Flag}}</div>
+{{#Flag similarity}}<div class="info">${sentence.flag-similar}</div>{{/Flag similarity}}
+</div>

--- a/templates/ultimate-geography/flag-country/question.html
+++ b/templates/ultimate-geography/flag-country/question.html
@@ -1,0 +1,10 @@
+<div dir="${text.direction}">
+{{#Flag}}
+  <div class="value value--top">?</div>
+
+  <hr>
+
+  <div class="type">${label.flag}</div>
+  <div class="value value--image value--front">{{Flag}}</div>
+{{/Flag}}
+</div>

--- a/templates/ultimate-geography/map-country/answer.html
+++ b/templates/ultimate-geography/map-country/answer.html
@@ -1,17 +1,4 @@
 <div dir="${text.direction}">
-{{#Map}}
-  <div class="value value--top">?</div>
-
-  <hr>
-
-  <div class="type">${label.location}</div>
-  <div class="value value--image">{{Map}}</div>
-{{/Map}}
-</div>
-
---
-
-<div dir="${text.direction}">
 <div id=answer class="value value--top">{{Country}}</div>
 {{#Country info}}<div class="info">{{Country info}}</div>{{/Country info}}
 

--- a/templates/ultimate-geography/map-country/question.html
+++ b/templates/ultimate-geography/map-country/question.html
@@ -1,0 +1,10 @@
+<div dir="${text.direction}">
+{{#Map}}
+  <div class="value value--top">?</div>
+
+  <hr>
+
+  <div class="type">${label.location}</div>
+  <div class="value value--image">{{Map}}</div>
+{{/Map}}
+</div>


### PR DESCRIPTION
# Split combined card templates

**Stack:** 13 of 14  
**Bookmark:** `brainbrew/12-split-templates`  
**Depends on:** `brainbrew/11-media-names`

## Summary

- Split all seven historical combined HTML templates into fourteen question/answer files.
- Replace fragment includes with ordinary whole-file includes.
- Remove every combined source without wrappers or duplicate copies.

## Why

The combined files were retained during migration to prove historical equivalence. With cutover complete, dedicated files are simpler to edit and no longer depend on fragment semantics.

## Validation

- Every split file is byte-identical to alpha.8's resolved parent fragment, including newline boundaries.
- All 48 composed decks, CrowdAnki exports, and media trees remain identical to the parent PR.
- RTL, localization, styling, and adapter identities are unchanged.
